### PR TITLE
fix regression on non systemd debian

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,3 +11,4 @@
 
 - name: reload systemd
   shell: systemctl daemon-reload
+  when: systemd.stat.exists == true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -13,17 +13,12 @@
   template: src=logrotate.conf.j2 dest=/etc/logrotate.d/mongodb.conf
   when: mongodb_logrotate
 
-#- name: reload systemd
-#  shell: systemctl daemon-reload
-#  when: systemd.stat.exists == true
-#  changed_when: false
-
 - name: ensure mongodb started and enabled
   service: name={{ mongodb_daemon_name }} state=started enabled=yes
 
 - name: wait MongoDB port is listening
-  wait_for: host="{{ mongodb_conf_bind_ip }}"port="{{ mongodb_conf_port }}" delay=5 state=started
-  when: systemd.stat.exists == true
+  wait_for: host="{{ mongodb_conf_bind_ip }}"port="{{ mongodb_conf_port }}" delay=10 timeout=60 state=started
+  #when: systemd.stat.exists == true
 
 - include: auth_initialization.yml
   when: mongodb_conf_auth

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -3,7 +3,7 @@
 - include_vars: "{{ansible_distribution}}.yml"
 
 - name: Check if systemd is present
-  stat: path=/lib/systemd/system/
+  stat: path=/bin/systemd
   register: systemd
 
 - name: Add systemd configuration if present
@@ -28,9 +28,11 @@
 
 - name: Install MongoDB package
   apt: pkg={{mongodb_package}} state=present
-  notify: reload systemd
 
-- meta: flush_handlers
+- name: reload systemd
+  shell: systemctl daemon-reload
+  changed_when: false
+  when: systemd.stat.exists == true
 
 - name: Install additional packages
   apt: pkg={{item}}


### PR DESCRIPTION
Hi,

This fixes a regression caused by the introduction of systemd in the role. It works on Debian Wheezy. Sorry for the trouble.

I also changed systemd check detection on the binary instead of a folder path because it looks like more or less present in standard Wheezy distribution. The binary requires to have systemd package installed, so it should be better.

Thanks