### PR TITLE
fixing systemd issue with docker

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -18,7 +18,7 @@
 
 - name: wait MongoDB port is listening
   wait_for: host="{{ mongodb_conf_bind_ip }}"port="{{ mongodb_conf_port }}" delay=10 timeout=60 state=started
-  #when: systemd.stat.exists == true
+  when: "'systemd' in systemd.stdout"
 
 - include: auth_initialization.yml
   when: mongodb_conf_auth

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -2,21 +2,21 @@
 
 - include_vars: "{{ansible_distribution}}.yml"
 
-- name: Check if systemd is present
-  stat: path=/bin/systemd
+- name: Check if running on systemd
+  command: cat /proc/1/cmdline
   register: systemd
 
 - name: Add systemd configuration if present
   copy: src=mongodb.service dest=/lib/systemd/system/mongodb.service owner=root group=root mode=0640
-  when: systemd.stat.exists == true
+  when: "'systemd' in systemd.stdout"
 
 - name: Add symlink for systemd
   file: src=/lib/systemd/system/mongodb.service dest=/etc/systemd/system/multi-user.target.wants/mongodb.service state=link
-  when: systemd.stat.exists == true
+  when: "'systemd' in systemd.stdout"
   notify: reload systemd
 
 - meta: flush_handlers
-  when: systemd.stat.exists == true
+  when: "'systemd' in systemd.stdout"
 
 - name: Add APT key
   apt_key: url=http://docs.mongodb.org/10gen-gpg-key.asc id=7F0CEB10
@@ -32,7 +32,7 @@
 - name: reload systemd
   shell: systemctl daemon-reload
   changed_when: false
-  when: systemd.stat.exists == true
+  when: "'systemd' in systemd.stdout"
 
 - name: Install additional packages
   apt: pkg={{item}}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,15 @@
 
 - include: install.deb.yml
   when: ansible_os_family == 'Debian'
+  tags: [mongodb]
 
 - include: configure.yml
+  tags: [mongodb]
 
 - include: replication.yml
   when: mongodb_conf_replSet != ""
+  tags: [mongodb]
 
 - include: mms-agent.yml
   when: mongodb_mms_api_key != ""
+  tags: [mongodb]


### PR DESCRIPTION
Updating systemd detection by getting PID 1 command line instead of
checking systemd folder. This to avoid issues with Docker for example.