### PR TITLE
feat: adding service managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ mongodb_package: mongodb-org
 mongodb_additional_packages:
 - python-pymongo
 
+mongodb_manager_service: true
+
 mongodb_user: mongodb
 mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ mongodb_package: mongodb-org
 mongodb_additional_packages:
 - python-pymongo
 
+mongodb_manager_service: true
+
 mongodb_user: mongodb
 mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,13 +2,16 @@
 
 - name: mongodb reload
   service: name={{ mongodb_daemon_name }} state=reloaded
+  when: mongodb_manager_service
 
 - name: mongodb restart
   service: name={{ mongodb_daemon_name }} state=restarted
+  when: mongodb_manager_service
 
 - name: mongodb-mms-automation-agent restart
   service: name=mongodb-mms-automation-agent state=restarted
+  when: mongodb_manager_service
 
 - name: reload systemd
   shell: systemctl daemon-reload
-  when: systemd.stat.exists == true
+  when: systemd.stat.exists == true and mongodb_manager_service

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -15,6 +15,7 @@
 
 - name: ensure mongodb started and enabled
   service: name={{ mongodb_daemon_name }} state=started enabled=yes
+  when: mongodb_manager_service
 
 - name: wait MongoDB port is listening
   wait_for: host="{{ mongodb_conf_bind_ip }}"port="{{ mongodb_conf_port }}" delay=10 timeout=60 state=started
@@ -38,4 +39,4 @@
 
 - name: mongodb restart
   service: name={{ mongodb_daemon_name }} state=restarted
-  when: config_result|changed
+  when: config_result|changed and mongodb_manager_service

--- a/tasks/mms-agent.yml
+++ b/tasks/mms-agent.yml
@@ -17,3 +17,4 @@
 
 - name: Ensure that the MMS agent is started
   service: name=mongodb-mms-automation-agent state=started enabled=yes
+  when: mongodb_manager_service


### PR DESCRIPTION
Hi,

Docker may not be able to start services (including MongoDB) when coupled with Systemd. That's why it's better to be able to manage the service.

This PR give the possibility to let the role manage or not the service.

Can you please merge and make a new version ?

Thanks