### PR TITLE
don't set  quotaFiles  if mongodb_conf_quota is false

### DIFF
--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -16,7 +16,9 @@ noscripting = {{ mongodb_conf_noscripting|to_nice_json }}
 notablescan = {{ mongodb_conf_notablescan|to_nice_json }}
 port = {{ mongodb_conf_port }}
 quota = {{ mongodb_conf_quota|to_nice_json }}
+{% if mongodb_conf_quota %}
 quotaFiles = {{ mongodb_conf_quotaFiles }}
+{% endif %}
 syslog = {{ mongodb_conf_syslog|to_nice_json }}
 smallfiles = {{ mongodb_conf_smallfiles|to_nice_json }}
 


### PR DESCRIPTION
because  quotaFiles option  implies --quota . 

quotaFiles   "number of files allowed per db, implies --quota"  
see mongodb source code : 
https://github.com/mongodb/mongo/blob/ef7f17be8085488ba965286fb97927a7ce3600e7/src/mongo/db/mongod_options.cpp#L223