### PR TITLE
Ability to install PyMongo from PIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Ansible role which manage [MongoDB](http://www.mongodb.org/)
 mongodb_package: mongodb-org
 
 mongodb_force_wait_for_port: false                # When not forced, the role will wait for mongod port to become available only with systemd
-mongodb_additional_packages:
-- python-pymongo
+mongodb_pymongo_from_pip: false                   # Install latest PyMongo via PIP or package manager
 
 mongodb_user: mongodb
 mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,7 @@
 
 mongodb_package: mongodb-org
 mongodb_force_wait_for_port: false
-
-mongodb_additional_packages:
-- python-pymongo
+mongodb_pymongo_from_pip: false                   # Install latest PyMongo via PIP or package manager
 
 mongodb_user: mongodb
 mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -34,6 +34,18 @@
   changed_when: false
   when: "'systemd' in systemd.stdout"
 
-- name: Install additional packages
-  apt: pkg={{item}}
-  with_items: mongodb_additional_packages
+- name: Install PyMongo package
+  apt: pkg=python-pymongo state=latest
+  when: not mongodb_pymongo_from_pip
+
+- name: Install PIP dependencies
+  apt: pkg={{ item }}
+  with_items:
+    - python-dev
+    - python-pip
+  when: mongodb_pymongo_from_pip
+
+- name: Install PyMongo from PIP
+  pip: name=pymongo state=latest
+  when: mongodb_pymongo_from_pip
+

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -38,7 +38,7 @@
   apt: pkg=python-pymongo state=latest
   when: not mongodb_pymongo_from_pip
 
-- name: Install PIP dependencies
+- name: Install PIP
   apt: pkg={{ item }}
   with_items:
     - python-dev


### PR DESCRIPTION
It turned out that `python-pymongo` package for Ubuntu 14.04 contains outdated `pymongo` module (version 2.6.3) which uses obsolete authentication schema incompatible with MongoDB v2.6.9. This way, when it's used to create MongoDB users, the further authentication fails without [upgrading auth schema](http://docs.mongodb.org/manual/reference/command/authSchemaUpgrade/#dbcmd.authSchemaUpgrade) manually on each DB server.

So this PR includes an ability to install latest PyMongo (2.8 at the moment) via [PIP](https://pip.pypa.io/en/latest/) which works fine with latest MongoDB v2.6.9.