### PR TITLE
fixing creation user fail when not managing service and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ mongodb_package: mongodb-org
 mongodb_force_wait_for_port: false                # When not forced, the role will wait for mongod port to become available only with systemd
 mongodb_pymongo_from_pip: false                   # Install latest PyMongo via PIP or package manager
 
-mongodb_manager_service: true
+mongodb_manage_service: true
 
 mongodb_user: mongodb
 mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ mongodb_package: mongodb-org
 mongodb_force_wait_for_port: false
 mongodb_pymongo_from_pip: false                   # Install latest PyMongo via PIP or package manager
 
-mongodb_manager_service: true
+mongodb_manage_service: true
 
 mongodb_user: mongodb
 mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,16 +2,16 @@
 
 - name: mongodb reload
   service: name={{ mongodb_daemon_name }} state=reloaded
-  when: mongodb_manager_service
+  when: mongodb_manage_service
 
 - name: mongodb restart
   service: name={{ mongodb_daemon_name }} state=restarted
-  when: mongodb_manager_service
+  when: mongodb_manage_service
 
 - name: mongodb-mms-automation-agent restart
   service: name=mongodb-mms-automation-agent state=restarted
-  when: mongodb_manager_service
+  when: mongodb_manage_service
 
 - name: reload systemd
   shell: systemctl daemon-reload
-  when: systemd.stat.exists == true and mongodb_manager_service
+  when: systemd.stat.exists == true and mongodb_manage_service

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Register default MongoDB listen IP
   set_fact: mongodb_listen_ip=127.0.0.1
   when: ansible_local.mongodb.mongodb.mongodb_listen_ip is undefined
@@ -6,7 +7,6 @@
 - name: Register MongoDB listen IP
   set_fact: mongodb_listen_ip={{ ansible_local.mongodb.mongodb.mongodb_listen_ip }}
   when: ansible_local.mongodb.mongodb.mongodb_listen_ip is defined
-
 
 - name: Create keyFile
   copy:
@@ -23,7 +23,16 @@
 
 - name: ensure mongodb started and enabled
   service: name={{ mongodb_daemon_name }} state=started enabled=yes
-  when: mongodb_manager_service
+  when: mongodb_manage_service
+
+- name: get pid of mongod
+  command: pidof mongod
+  register: mongod_pid
+  ignore_errors: True
+
+- name: temporary start mongod if not started
+  command: '/usr/bin/mongod --config /etc/mongod.conf --fork'
+  when: mongod_pid.rc != 0
 
 - name: wait MongoDB port is listening
   wait_for: host="{{ mongodb_listen_ip }}" port="{{ mongodb_conf_port }}" delay=10 timeout=60 state=started
@@ -51,6 +60,15 @@
   template: src=mongod.conf.j2 dest=/etc/mongod.conf backup=yes owner=root group=root mode=0644
   register: config_result
 
+- name: get pid of mongod
+  command: pidof mongod
+  register: mongod_new_pid
+  when: mongod_pid.rc != 0
+
+- name: kill temporary mongod if started
+  command: kill {{ mongod_new_pid.stdout }}
+  when: mongod_pid.rc != 0
+
 - name: mongodb restart
   service: name={{ mongodb_daemon_name }} state=restarted
-  when: config_result|changed and mongodb_manager_service
+  when: config_result|changed and mongodb_manage_service

--- a/tasks/mms-agent.yml
+++ b/tasks/mms-agent.yml
@@ -17,4 +17,4 @@
 
 - name: Ensure that the MMS agent is started
   service: name=mongodb-mms-automation-agent state=started enabled=yes
-  when: mongodb_manager_service
+  when: mongodb_manage_service


### PR DESCRIPTION
Hi,

I encounter an issue when I do not want the service to be managed by Ansible, but do not get a running instance of Mongo.

This fix will temporary start a Mongo instance, apply what is has to do and then kill the instance. Can you please review it and merge if ok.

Thanks