### PR TITLE
Disable Linux THP on Debian distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ mongodb_package: mongodb-org
 
 mongodb_force_wait_for_port: false                # When not forced, the role will wait for mongod port to become available only with systemd
 mongodb_pymongo_from_pip: false                   # Install latest PyMongo via PIP or package manager
+mongodb_disable_thp: true
 
 mongodb_user: mongodb
 mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 mongodb_package: mongodb-org
 mongodb_force_wait_for_port: false
 mongodb_pymongo_from_pip: false                   # Install latest PyMongo via PIP or package manager
+mongodb_disable_thp: true
 
 mongodb_user: mongodb
 mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"

--- a/files/disable_thp.sh
+++ b/files/disable_thp.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if test -f /sys/kernel/mm/transparent_hugepage/khugepaged/defrag; then
+  echo 0 > /sys/kernel/mm/transparent_hugepage/khugepaged/defrag
+fi
+if test -f /sys/kernel/mm/transparent_hugepage/defrag; then
+  echo never > /sys/kernel/mm/transparent_hugepage/defrag
+fi
+if test -f /sys/kernel/mm/transparent_hugepage/enabled; then
+  echo never > /sys/kernel/mm/transparent_hugepage/enabled
+fi

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -50,6 +50,18 @@
   template: src=mongod.conf.j2 dest=/etc/mongod.conf backup=yes owner=root group=root mode=0644
   register: config_result
 
+- name: Install disable_thp script
+  copy: src=disable_thp.sh dest=/usr/local/bin/disable_thp.sh mode='u=rwx,g=rx,o=rx'
+  when: ansible_os_family == 'Debian' and mongodb_disable_thp
+
+- name: Disable Linux transparent hugepages now
+  command: /usr/local/bin/disable_thp.sh
+  when: ansible_os_family == 'Debian' and mongodb_disable_thp
+
+- name: Disable Linux transparent hugepages on boot
+  lineinfile: dest=/etc/rc.local regexp='/usr/local/bin/disable_thp.sh' line='if test -f '/usr/local/bin/disable_thp.sh'; /usr/local/bin/disable_thp.sh; fi'
+  when: ansible_os_family == 'Debian' and mongodb_disable_thp
+
 - name: mongodb restart
   service: name={{ mongodb_daemon_name }} state=restarted
   when: config_result|changed


### PR DESCRIPTION
http://docs.mongodb.org/manual/reference/transparent-huge-pages/#in-etc-rc-local-alternate
https://jira.mongodb.org/browse/DOCS-2131

Can be disabled by setting `mongodb_disable_thp ` var to `false`