### PR TITLE
can set uid and gid of mongodb user

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ mongodb_disable_thp: true
 mongodb_manage_service: true
 
 mongodb_user: mongodb
+mongodb_uid:
+mongodb_gid:
 mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"
 
 mongodb_conf_auth: false                          # Run with security

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ mongodb_disable_thp: true
 mongodb_manage_service: true
 
 mongodb_user: mongodb
+mongodb_uid:
+mongodb_gid:
 mongodb_daemon_name: "{{ 'mongod' if ('mongodb-org' in mongodb_package) else 'mongodb' }}"
 
 mongodb_conf_auth: false                          # Run with security

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: set mongodb gid
+  group: name=mongodb gid={{ mongodb_gid }} state=present
+  when: mongodb_gid
+
+- name: set mongodb uid
+  user: name=mongodb uid={{ mongodb_uid }} group=mongodb state=present
+  when: mongodb_uid
+
 - name: Register default MongoDB listen IP
   set_fact: mongodb_listen_ip=127.0.0.1
   when: ansible_local.mongodb.mongodb.mongodb_listen_ip is undefined


### PR DESCRIPTION
Hi,

In some case like Cloud or Docker, it's useful to use persistent disk for mongodb. A possible problem can occur. It is to get a different a different uid/gid which can lead to read/write problem at start.

That's why I added this to force the uid and gid to avoid issue in that case.

Thanks to merge this PR