### PR TITLE
feature: adding right reset when modifying uid

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,6 +8,10 @@
   user: name=mongodb uid={{ mongodb_uid }} group=mongodb state=present
   when: mongodb_uid
 
+- name: reset mongodb folder and subfolders with new uid
+  file: path={{ mongodb_conf_dbpath }} owner=mongodb group=mongodb follow=yes recurse=yes state=directory
+  when: mongodb_uid
+
 - name: Register default MongoDB listen IP
   set_fact: mongodb_listen_ip=127.0.0.1
   when: ansible_local.mongodb.mongodb.mongodb_listen_ip is undefined


### PR DESCRIPTION
Hi,

Changing the uid is a good thing when set on a fresh mongo install but it's better to reset rights to avoid issues on an existing instance.