### PR TITLE
Adding numactl package

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -28,7 +28,10 @@
   when: '"mongodb-org" in mongodb_package'
 
 - name: Install MongoDB package
-  apt: pkg={{mongodb_package}} state=present
+  apt: name={{item}} state=present
+  with_items:
+    - "{{mongodb_package}}"
+    - numactl
 
 - name: reload systemd
   shell: systemctl daemon-reload


### PR DESCRIPTION
More and more physical servers are running on numa infrastructure. To
get best performances, numactl is required.