### PR TITLE
Ensure /data/db directory on debina

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -27,6 +27,9 @@
   apt_repository: repo="{{mongodb_repository}}" update_cache=yes
   when: '"mongodb-org" in mongodb_package'
 
+- name: Endure /data directory
+  file: path=/data/db state=directory owner=mongodb recurse=yes
+
 - name: Install MongoDB package
   apt: name={{item}} state=present
   with_items:


### PR DESCRIPTION
It appears that standard mongo install process on debian doesn't create the /data/db directory. This prevents mongo process from starting and required manual job on the server.

With this fix the /data/db directory will be created by ansible during install process.