### PR TITLE
parameterize apt key and apt repo url variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 
 mongodb_package: mongodb-org
+mongodb_apt_key_url: http://docs.mongodb.org/10gen-gpg-key.asc
+mongodb_apt_key_id: 7F0CEB10
 mongodb_force_wait_for_port: false
 mongodb_pymongo_from_pip: false                   # Install latest PyMongo via PIP or package manager
 mongodb_disable_thp: true

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -20,12 +20,10 @@
   when: "'systemd' in systemd.stdout"
 
 - name: Add APT key
-  apt_key: url=http://docs.mongodb.org/10gen-gpg-key.asc id=7F0CEB10
-  when: '"mongodb-org" in mongodb_package'
+  apt_key: url="{{mongodb_apt_key_url}}" id="{{mongodb_apt_key_id}}"
 
 - name: Add APT repository
   apt_repository: repo="{{mongodb_repository}}" update_cache=yes
-  when: '"mongodb-org" in mongodb_package'
 
 - name: Endure /data directory
   file: path=/data/db state=directory owner=mongodb recurse=yes


### PR DESCRIPTION
remove when conditional for the same

these steps were skipped when i specified my own mongodb-package