### PR TITLE
Use mongodb_conf_dbpath rather than a hard-coded path name

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -31,8 +31,8 @@
     - "{{mongodb_package}}"
     - numactl
 
-- name: Ensure /data directory
-  file: path=/data/db state=directory owner=mongodb recurse=yes
+- name: Ensure dbpath directory
+  file: path={{mongodb_conf_dbpath}} state=directory owner=mongodb recurse=yes
 
 - name: reload systemd
   shell: systemctl daemon-reload


### PR DESCRIPTION
The task that ensures the database directory is created with correct ownership is hard-coded to the default value, `/data/db`.  This means supplying a value for `mongodb_conf_dbpath` changes the configuration, but will (likely) result in errors when MongoDB attempts to use the location.  This PR simply supplies the variable name into the task so that things work as expected.