### PR TITLE
Revert "Adding wait after mongodb restart"

### DIFF
--- a/tasks/auth_initialization.yml
+++ b/tasks/auth_initialization.yml
@@ -6,9 +6,6 @@
   service: name={{ mongodb_daemon_name }} state=restarted
   when: mongodb_manage_service
 
-- name: wait MongoDB port is listening
-  wait_for: host="{{ mongodb_conf_bind_ip }}"port="{{ mongodb_conf_port }}" delay=5 state=started
-
 - name: get pid of mongodb for non daemon mode
   shell: "pidof mongod"
   register: pidof_mongod
@@ -66,9 +63,6 @@
 - name: Restart mongodb service
   service: name={{ mongodb_daemon_name }} state=restarted
   when: mongodb_manage_service
-
-- name: wait MongoDB port is listening
-  wait_for: host="{{ mongodb_conf_bind_ip }}"port="{{ mongodb_conf_port }}" delay=5 state=started
 
 - name: stop mongodb if was not started
   shell: "kill {{ pidof_mongod.stdout }}"


### PR DESCRIPTION
Reverts UnderGreen/ansible-role-mongodb#38

We figured out that this won't work out as expected because of 2 reasons:
* ```host="{{ mongodb_conf_bind_ip }}"port="{{ mongodb_conf_port }}" delay=5 state=started``` has the module args without spaces between them so ansible basically ignores all of this.
* The first wait_for should have ```host=127.0.0.1``` instead of  ```mongodb_conf_bind_ip````

I'll create another PR with the above fixed. But in the meantime please revert this one.