### PR TITLE
Add support for hidden repl members and priorities

### DIFF
--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -10,6 +10,8 @@
     host_name: "{{ item.host_name }}"
     host_port: "{{ item.host_port|default(27017) }}"
     host_type: "{{ item.host_type|default('replica') }}"
+    hidden: "{{ item.hidden|default(false) }}"
+    priority: "{{ item.priority|default(1.0) }}"
   when: mongodb_conf_auth and mongodb_replication_params is defined
   with_items:
     - "{{ mongodb_replication_params }}"
@@ -22,6 +24,8 @@
     host_name: "{{ item.host_name }}"
     host_port: "{{ item.host_port|default(27017) }}"
     host_type: "{{ item.host_type|default('replica') }}"
+    hidden: "{{ item.hidden|default(false) }}"
+    priority: "{{ item.priority|default(1.0) }}"
   when: not mongodb_conf_auth and mongodb_replication_params is defined
   with_items:
     - "{{ mongodb_replication_params }}"

--- a/tasks/replication_init_auth.yml
+++ b/tasks/replication_init_auth.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Replication configuration
   mongodb_replication:
     login_host: "{{ mongodb_login_host|default('localhost') }}"
@@ -10,6 +9,8 @@
     host_name: "{{ item.host_name }}"
     host_port: "{{ item.host_port|default(27017) }}"
     host_type: "{{ item.host_type|default('replica') }}"
+    hidden: "{{ item.hidden|default(false) }}"
+    priority: "{{ item.priority|default(1.0) }}"
   with_items:
     - "{{ mongodb_replication_params }}"
   register: mongodb_replica_init
@@ -28,6 +29,8 @@
     host_name: "{{ item.host_name }}"
     host_port: "{{ item.host_port|default(27017) }}"
     host_type: "{{ item.host_type|default('replica') }}"
+    hidden: "{{ item.hidden|default(false) }}"
+    priority: "{{ item.priority|default(1.0) }}"
   with_items:
     - "{{ mongodb_replication_params }}"
   when: mongodb_replica_init|failed


### PR DESCRIPTION
Currently `ansible-role-mongodb` does not support replicaset member configuration options as "hidden" and "priority".

This commit attempts to solve the problem described above. Support for attributes "hidden" and "priority" has been added, and can be established in the following way:

    mongodb_replication_params:
      - { host_name: mongo-hidden, priority: 0, hidden: true }

Fixes #41 