### PR TITLE
Fix replicaset config without authentication

### DIFF
--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -27,5 +27,7 @@ smallfiles = {{ mongodb_conf_smallfiles|to_nice_json }}
 replSet = {{ mongodb_conf_replSet }}
 replIndexPrefetch = {{ mongodb_conf_replIndexPrefetch }}
 oplogSize = {{ mongodb_conf_oplogSize }}
+{% endif %}
+{% if mongodb_conf_replSet and mongodb_conf_auth %}
 keyFile = {{ mongodb_conf_keyFile }}
 {% endif %}


### PR DESCRIPTION
According to MongoDB documentation (https://docs.mongodb.org/v3.0/tutorial/enable-internal-authentication/), "enabling internal authentication (in a replicaset) enables access control". Therefore, if MongoDB is configured without authentication (`auth = no`) a `keyFile` line must not appear in the configuration file.

This commit attempts to solve the problem described above. An extra check has been added to ensure the `keyFile` configuration option is added only if replicaset authorization _and_ authentication is enabled.

Fix #43 