### PR TITLE
Resolved error in single-node installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,12 +8,12 @@
   tags: [mongodb]
 
 - include: replication_init_auth.yml
-  when: ( mongodb_conf_replSet is defined and mongodb_conf_auth
+  when: ( mongodb_conf_replSet and mongodb_conf_auth
         and mongodb_master is defined and mongodb_master )
   tags: [mongodb]
 
 - include: replication.yml
-  when: mongodb_conf_replSet is defined
+  when: mongodb_conf_replSet
   tags: [mongodb]
 
 - include: auth_initialization.yml


### PR DESCRIPTION
If we use only one node without replication, we're get this error:
```
TASK [greendayonfire.mongodb : Replication configuration] **********************
fatal: [mongo]: FAILED! => {"failed": true, "msg": "ERROR! 'mongodb_replication_params' is undefined"}
```

Its raised by `replication.yml`, which applied to node, although replication is disabled. It caused by wrong conditionals in `tasks/main.yml`. In previous version **`replication.yml` launched when `mongodb_conf_replSet` is defined, but it always defined (but empty) in `defaults/main.yml`**. I suggest change this condition (and replication_init_auth condition) from `mongodb_conf_replSet is defined` to `mongodb_conf_replSet != ''` or simple `mongodb_conf_replSet`.