### PR TITLE
Ensure dbpath directory has configurable owner

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -32,6 +32,13 @@
   file: state=touch dest={{ mongodb_systemlog_path }} owner={{ mongodb_user }} group={{mongodb_user}} mode=0755
   when: logfile_stat is defined and not logfile_stat.stat.exists
 
+- name: Ensure dbpath directory
+  file:
+    path: "{{ mongodb_storage_dbpath }}"
+    state: directory
+    owner: "{{ mongodb_user }}"
+    recurse: yes
+
 - name: Configure mongodb
   template: src=mongod.conf.j2 dest=/etc/mongod.conf backup=yes owner=root group=root mode=0644
   register: config_result

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -44,9 +44,6 @@
     - "{{mongodb_package}}"
     - numactl
 
-- name: Ensure dbpath directory
-  file: path={{mongodb_storage_dbpath}} state=directory owner=mongodb recurse=yes
-
 - name: reload systemd
   shell: systemctl daemon-reload
   changed_when: false


### PR DESCRIPTION
Looks like when this variable was introduced, this particular task was
missed.

This has also been moved to the configuration stage, since it seems to
fit with the task for ensuring the log directory exists, too.