### PR TITLE
Fix connection failure to Docker hosts in test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,9 @@ services:
 
 before_install:
   - sudo apt-get update
-  # Latest Ansible install
-  - sudo apt-add-repository -y ppa:ansible/ansible
-  - sudo apt-get update
-  - sudo apt-get install ansible python-pip -y
+  - sudo apt-get install python-pip -y
+  # 2.0.2 is unable to connect using the docker connection driver
+  - sudo pip install ansible==2.0.1.0
   - sudo pip install docker-py==1.5.0
   # Pull docker image
   - sudo docker pull ${DISTRIBUTION}:${DIST_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
   - sudo pip install docker-py==1.5.0
   # Pull docker image
   - sudo docker pull ${DISTRIBUTION}:${DIST_VERSION}
-  - sudo ln -s ${PWD} /etc/ansible/roles/greendayonfire.mongodb
+  - ln -s ${PWD} tests/greendayonfire.mongodb
   
 script:
   # Test 1


### PR DESCRIPTION
It seems that there is a bug in the 2.0.2 PPA package that is preventing
the Docker connection driver from working correctly. The resulting error
looks something like:

> fatal: [mongo1]: UNREACHABLE! => {"changed": false, "msg":
  "Authentication or permission failure. In some cases, you may have
  been able to authenticate and did not have permissions on the remote
  directory. Consider changing the remote temp path in ansible.cfg to a
  path rooted in \"/tmp\". Failed command was: ( umask 22 && mkdir -p
  \"` echo $HOME/.ansible/tmp/ansible-tmp-1461808016.45-51742099619529
  `\" && echo \"` echo
  $HOME/.ansible/tmp/ansible-tmp-1461808016.45-51742099619529 `\" ),
  exited with result 255", "unreachable": true}

Symptomatically, it looks very similar to an issue already reported
in Ansible, but it currently contains very mixed reports:
ansible/ansible#13876