### PR TITLE
Enabling check_mode

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -6,6 +6,7 @@
   command: cat /proc/1/cmdline
   register: systemd
   changed_when: false
+  always_run: yes # side-effect free, so it can be run in check-mode as well
 
 - name: Add systemd configuration if present
   copy: src=mongodb.service dest=/lib/systemd/system/mongodb.service owner=root group=root mode=0640

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,7 @@
           -p {{ mongodb_user_admin_password }} --eval 'db.version()' admin
   register: mongodb_user_admin_check
   changed_when: false
+  always_run: yes # side-effect free, so it can be run in check-mode as well
   ignore_errors: true
   when: ( mongodb_security_authorization == 'enabled'
           and (not mongodb_replication_replset


### PR DESCRIPTION
I identified two script tasks which prevented the role to be used in check_mode. I added an "always_run = yes" to them as I am fairly certain those task are read-only / side-effect free. So they can be run in check_mode without negative consequences.