### PR TITLE
Fix systemd test for Ubuntu Xenial

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -3,22 +3,22 @@
 - include_vars: "{{ansible_distribution}}.yml"
 
 - name: Check if running on systemd
-  command: cat /proc/1/cmdline
-  register: systemd
+  stat: path=/sbin/init
+  register: sbin_init
   changed_when: false
   always_run: yes # side-effect free, so it can be run in check-mode as well
 
 - name: Add systemd configuration if present
   copy: src=mongodb.service dest=/lib/systemd/system/mongodb.service owner=root group=root mode=0640
-  when: "'systemd' in systemd.stdout"
+  when: sbin_init.stat.islnk is defined and sbin_init.stat.islnk
 
 - name: Add symlink for systemd
   file: src=/lib/systemd/system/mongodb.service dest=/etc/systemd/system/multi-user.target.wants/mongodb.service state=link
-  when: "'systemd' in systemd.stdout"
+  when: sbin_init.stat.islnk is defined and sbin_init.stat.islnk
   notify: reload systemd
 
 - meta: flush_handlers
-  when: "'systemd' in systemd.stdout"
+  when: sbin_init.stat.islnk is defined and sbin_init.stat.islnk
 
 - name: Add APT key
   apt_key:
@@ -48,7 +48,7 @@
 - name: reload systemd
   shell: systemctl daemon-reload
   changed_when: false
-  when: "'systemd' in systemd.stdout"
+  when: sbin_init.stat.islnk is defined and sbin_init.stat.islnk
 
 - name: Install PyMongo package
   apt: pkg=python-pymongo state=latest


### PR DESCRIPTION
The role checks if the system is running or not systemd. It checks the name of the process with PID1, and if it contains the string "systemd" assumes that the host is systemd-based. Unfortunately that check fails in Ubuntu Xenial:

```
vagrant@mongo-xenial:~$ cat /proc/1/cmdline
/sbin/init
```

A better approach may be to check if /sbin/init is a symlink or a binary. In systemd-based systems (e.g. Ubuntu Xenial), /sbin/init is a symlink to the systemd binary:

```
vagrant@mongo-xenial:~$ file /sbin/init
/sbin/init: symbolic link to /lib/systemd/systemd
```

In Ubuntu Trusty /sbin/init is a binary:

```
vagrant@mongo-trusty:~$ file /sbin/init
/sbin/init: ELF 64-bit LSB  shared object, x86-64, version 1 (SYSV), dynamically linked (uses shared libs), for GNU/Linux 2.6.24, BuildID[sha1]=7a4c688d009fc1f06ffc692f5f42ab09e68582b2, stripped
```

This PR attempts to solve the problem described above. The systemd check has been rewritten to check if /sbin/init is a binary or a symlink.