### PR TITLE
Do not show passwords in Ansible output

### DIFF
--- a/tasks/auth_initialization.yml
+++ b/tasks/auth_initialization.yml
@@ -33,6 +33,7 @@
       password: "{{ mongodb_user_admin_password }}",
       roles: "userAdminAnyDatabase"
       }
+  no_log: true
 
 - name: create administrative user siteRootAdmin
   mongodb_user:
@@ -48,6 +49,7 @@
       password: "{{ mongodb_root_admin_password }}",
       roles: "root"
       }
+  no_log: true
 
 - name: create backup user "backupuser"
   mongodb_user:
@@ -63,6 +65,7 @@
       password: "{{ mongodb_root_backup_password }}",
       roles: "backup,clusterMonitor"
       }
+  no_log: true
 
 - name: Move back mongod.conf
   template: src=mongod.conf.j2 dest=/etc/mongod.conf owner=root group=root mode=0644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,7 @@
   when: ( mongodb_security_authorization == 'enabled'
           and (not mongodb_replication_replset
           or mongodb_replication_replset == '') )
+  no_log: true
   tags: [mongodb]
 
 - name: Include authorization configuration
@@ -60,6 +61,7 @@
         and mongodb_replication_replset != ''
         and mongodb_security_authorization == 'enabled'
         and mongodb_master is defined and mongodb_master )
+  no_log: true
   tags: [mongodb]
 
 - name: create normal users without replicaset
@@ -77,6 +79,7 @@
   when: ( mongodb_security_authorization == 'enabled'
           and (not mongodb_replication_replset
           or mongodb_replication_replset == '') )
+  no_log: true
   tags: [mongodb]
 
 - name: Include MMS Agent configuration


### PR DESCRIPTION
This role prints passwords in Ansible outputs (e.g. when creating users, etc.). This is a problem because passwords must never appear in plaintext under any circumstances.

This commit attempts to fix the problem described above. The option "no_log: true" has been added to tasks which may print passwords during Ansible execution.