### PR TITLE
Fix (again) Systemd support

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,7 +14,7 @@
 
 - name: reload systemd
   shell: systemctl daemon-reload
-  when: systemd.stat.exists == true and mongodb_manage_service
+  when: mongodb_is_systemd and mongodb_manage_service
 
 - name: restart sysfsutils
   service: name=sysfsutils state=restarted

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -8,35 +8,39 @@
   changed_when: false
   always_run: yes # side-effect free, so it can be run in check-mode as well
 
+- name: Establish some role-related facts
+  set_fact:
+    mongodb_is_systemd: "{{ sbin_init.stat.islnk is defined and sbin_init.stat.islnk }}"
+    mongodb_major_version: "{{ mongodb_version[0:3] }}"
+
 - name: Add systemd configuration if present
   copy: src=mongodb.service dest=/lib/systemd/system/mongodb.service owner=root group=root mode=0640
-  when: sbin_init.stat.islnk is defined and sbin_init.stat.islnk
+  when: mongodb_is_systemd
 
 - name: Add symlink for systemd
   file: src=/lib/systemd/system/mongodb.service dest=/etc/systemd/system/multi-user.target.wants/mongodb.service state=link
-  when: sbin_init.stat.islnk is defined and sbin_init.stat.islnk
+  when: mongodb_is_systemd
   notify: reload systemd
 
 - meta: flush_handlers
-  when: sbin_init.stat.islnk is defined and sbin_init.stat.islnk
+  when: mongodb_is_systemd
 
 - name: Add APT key
   apt_key:
     keyserver: "{{mongodb_apt_keyserver}}"
     id: "{{mongodb_apt_key_id}}"
   when: mongodb_package == 'mongodb-org'
-  
+
 - name: Fail when used wrong mongodb_version variable
   fail:
     msg: "mongodb_version variable should be '2.6', '3.0' or '3.2'"
   when: (mongodb_package == 'mongodb-org' and
         (mongodb_version is not defined
-        or mongodb_repository[item] is not defined))
-  with_items: "{{ mongodb_version[0:3] }}"
-  
+         or mongodb_repository[mongodb_major_version] is not defined))
+
 - name: Add APT repository
   apt_repository: repo="{{ mongodb_repository[item] }}" update_cache=yes
-  with_items: "{{ mongodb_version[0:3] }}"
+  with_items: "{{ mongodb_major_version }}"
   when: mongodb_package == 'mongodb-org'
 
 - name: Install MongoDB package
@@ -48,7 +52,7 @@
 - name: reload systemd
   shell: systemctl daemon-reload
   changed_when: false
-  when: sbin_init.stat.islnk is defined and sbin_init.stat.islnk
+  when: mongodb_is_systemd
 
 - name: Install PyMongo package
   apt: pkg=python-pymongo state=latest

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -19,7 +19,7 @@ replication:
   secondaryIndexPrefetch: {{ mongodb_replication_replindexprefetch }}
   {% endif %}
 {% endif %}
-  
+
 security:
   authorization: {{ mongodb_security_authorization }}
   {% if mongodb_replication_replset and mongodb_security_authorization == 'enabled' -%}
@@ -28,7 +28,7 @@ security:
 
 storage:
   dbPath: {{ mongodb_storage_dbpath }}
-  {% if mongodb_version[0:3]|float >= 3.0 -%}
+  {% if mongodb_major_version|float >= 3.0 -%}
   engine: {{ mongodb_storage_engine }}
   {% endif -%}
   journal:
@@ -40,7 +40,7 @@ storage:
       maxFilesPerDB: {{ mongodb_storage_quota_maxfiles }}
     smallFiles: {{ mongodb_storage_smallfiles | to_nice_json }}
   {% endif -%}
-  {% if mongodb_version[0:3] == '2.6' -%}
+  {% if mongodb_major_version == '2.6' -%}
   quota:
     enforced: {{ mongodb_storage_quota_enforced | to_nice_json }}
     maxFilesPerDB: {{ mongodb_storage_quota_maxfiles }}
@@ -52,4 +52,3 @@ systemLog:
   destination: {{ mongodb_systemlog_destination }}
   logAppend: {{ mongodb_systemlog_logappend | to_nice_json }}
   path: {{ mongodb_systemlog_path }}
-

--- a/templates/mongod_init.conf.j2
+++ b/templates/mongod_init.conf.j2
@@ -10,13 +10,13 @@ net:
 
 processManagement:
   fork: {{ mongodb_processmanagement_fork | to_nice_json }}
-  
+
 security:
   authorization: 'disabled'
 
 storage:
   dbPath: {{ mongodb_storage_dbpath }}
-  {% if mongodb_version[0:3]|float >= 3.0 -%}
+  {% if mongodb_major_version|float >= 3.0 -%}
   engine: {{ mongodb_storage_engine }}
   {% endif -%}
   journal:
@@ -28,7 +28,7 @@ storage:
       maxFilesPerDB: {{ mongodb_storage_quota_maxfiles }}
     smallFiles: {{ mongodb_storage_smallfiles | to_nice_json }}
   {% endif -%}
-  {% if mongodb_version[0:3] == '2.6' -%}
+  {% if mongodb_major_version == '2.6' -%}
   quota:
     enforced: {{ mongodb_storage_quota_enforced | to_nice_json }}
     maxFilesPerDB: {{ mongodb_storage_quota_maxfiles }}


### PR DESCRIPTION
Commit #d9393b1 did not completely fixed the systemd-related issues. The handler `reload systemd` has  a `when` clause which fails in systemd-based systems.

This commit attempts to fix the problem described above. The `when` clause in the handler `reload systemd` has been fixed. Some facts has been added in the install playbook, in order to make the code more simple and easier to maintain.