### PR TITLE
Increase the file descriptor limit for the systemd service.

### DIFF
--- a/files/mongodb.service
+++ b/files/mongodb.service
@@ -5,6 +5,8 @@ Documentation=man:mongod(1)
 [Service]
 User=mongodb
 ExecStart=/usr/bin/mongod --config /etc/mongod.conf
+LimitNOFILE=65535
+LimitNPROC=65535
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The default service FD limit of 1024 is not sufficient for MongoDB
deployments that handle thousands of client connections and
databases.