### PR TITLE
Fixed issue with multi-port binding timeouts

### DIFF
--- a/tasks/auth_initialization.yml
+++ b/tasks/auth_initialization.yml
@@ -74,8 +74,9 @@
   service: name={{ mongodb_daemon_name }} state=restarted
   when: mongodb_manage_service
 
-- name: wait MongoDB port is listening
-  wait_for: host="{{ mongodb_net_bindip }}" port="{{ mongodb_net_port }}" delay=5 state=started
+- name: Wait MongoDB port is listening
+  wait_for: host="{{ item }}" port="{{ mongodb_net_port }}" delay=5 state=started
+  with_items: "{{ mongodb_net_bindip.split(',') | map('replace', '0.0.0.0', '127.0.0.1') | list }}"
 
 - name: stop mongodb if was not started
   shell: "kill {{ pidof_mongod.stdout }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -50,13 +50,9 @@
 - name: Ensure service is started
   service: name={{ mongodb_daemon_name }} state=started
 
-- name: Set fact about wait_for host address
-  set_fact:
-    wait_for_host: 127.0.0.1
-  when: mongodb_net_bindip == "0.0.0.0"
-  
 - name: Wait when mongodb is started
   wait_for:
-    host: "{{ wait_for_host | default(mongodb_net_bindip) }}"
+    host: "{{ item }}"
     port: "{{ mongodb_net_port }}"
     timeout: 120
+  with_items: "{{ mongodb_net_bindip.split(',') | map('replace', '0.0.0.0', '127.0.0.1') | list }}"


### PR DESCRIPTION
Hello! I'm trying to deploy instance of MongoDB to Digital Ocean and providing var `mongodb_net_bindip` with two ip's: localhost and private droplet address, gives me timeouts as described [here](https://github.com/UnderGreen/ansible-role-mongodb/issues/71) and [here](https://github.com/UnderGreen/ansible-role-mongodb/issues/46). 
I have replaced raw string with loop and it works fine for me. 
Could you please take a look and accept if everything is ok?