### PR TITLE
Add custom port in command to check if admin user exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,8 @@
 - name: Check user admin is exists
   command: >
     mongo --quiet -u {{ mongodb_user_admin_name }} \
-          -p {{ mongodb_user_admin_password }} --eval 'db.version()' admin
+          -p {{ mongodb_user_admin_password }} --port {{ mongodb_net_port }} --eval 'db.version()' admin
+
   register: mongodb_user_admin_check
   changed_when: false
   always_run: yes # side-effect free, so it can be run in check-mode as well


### PR DESCRIPTION
Bugfix: If using a custom port, checking if the admin user exists always return False, forcing a mongodb db restart to create it even if it is already existing, and an other restart to re-enable authentication.