### PR TITLE
add mongo 3.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Ansible role which manage [MongoDB](http://www.mongodb.org/).
 
 MongoDB support matrix:
 
-| Distribution | MongoDB 2.4 | MongoDB 2.6 | MongoDB 3.0 | MongoDB 3.2 |
-| ------------ |:-----------:|:-----------:|:-----------:|:-----------:|
-| Ubuntu 14.04 | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark:|
-| Ubuntu 12.04 | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark:|
-| Ubuntu 16.04 | :no_entry: | :x: | :x: | :x:|
-| Debian 7.x | :no_entry: | :interrobang: | :interrobang: | :interrobang:|
-| Debian 8.x | :no_entry: | :x: | :x: | :x:|
+| Distribution | MongoDB 2.4 | MongoDB 2.6 | MongoDB 3.0 | MongoDB 3.2 | MongoDB 3.4 |
+| ------------ |:-----------:|:-----------:|:-----------:|:-----------:|:-----------:|
+| Ubuntu 14.04 | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark:| :x:|
+| Ubuntu 12.04 | :no_entry: | :white_check_mark: | :white_check_mark: | :white_check_mark:| :x:|
+| Ubuntu 16.04 | :no_entry: | :x: | :x: | :x:| :x:|
+| Debian 7.x | :no_entry: | :interrobang: | :interrobang: | :interrobang:| :x:|
+| Debian 8.x | :no_entry: | :x: | :x: | :x:| :x:|
 
 :white_check_mark: - fully tested, should work fine  
 :interrobang: - will be added testing suite soon  
@@ -32,9 +32,9 @@ MongoDB support matrix:
 mongodb_package: mongodb-org
 
 # You can control installed version via this param.
-# Should be '2.6', '3.0' or '3.2'. This role does't support MongoDB < 2.4.
+# Should be '2.6', '3.0', '3.2' or '3.4'. This role does't support MongoDB < 2.4.
 # I will recommend you to use latest version of MongoDB.
-mongodb_version: "3.2"
+mongodb_version: "3.4"
 
 mongodb_force_wait_for_port: false               # When not forced, the role will wait for mongod port to become available only with systemd
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,14 @@
 ---
 
 mongodb_package: mongodb-org
-mongodb_version: "3.2"
+mongodb_version: "3.4"
 mongodb_apt_keyserver: keyserver.ubuntu.com
-mongodb_apt_key_id: "{{ 'EA312927' if mongodb_version[0:3] == '3.2' else '7F0CEB10' }}"
+mongodb_apt_key_id:
+  "2.6": "7F0CEB10"
+  "3.0": "7F0CEB10"
+  "3.2": "EA312927"
+  "3.4": "0C49F3730359A14518585931BC711F9BA15703C6"
+
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
 
 mongodb_force_wait_for_port: false

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -27,8 +27,8 @@
 
 - name: Add APT key
   apt_key:
-    keyserver: "{{mongodb_apt_keyserver}}"
-    id: "{{mongodb_apt_key_id}}"
+    keyserver: "{{ mongodb_apt_keyserver }}"
+    id: "{{ mongodb_apt_key_id[mongodb_major_version] }}"
   when: mongodb_package == 'mongodb-org'
 
 - name: Fail when used wrong mongodb_version variable

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,6 @@
 ---
-
 mongodb_repository:
   "2.6": "deb http://downloads-distro.mongodb.org/repo/debian-sysvinit dist 10gen"
   "3.0": "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.0 main"
-  "3.2": "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.2 main"
+  "3.2": "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/3.2 main"
+  "3.4": "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/3.4 main"

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,6 +1,6 @@
 ---
-
 mongodb_repository:
   "2.6": "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
   "3.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/3.0 multiverse"
   "3.2": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/3.2 multiverse"
+  "3.4": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/3.4 multiverse"


### PR DESCRIPTION
Hi,

This PR updates mongo repositories and repo key id for mongo 3.4.
Succesfully tested on Ubuntu 16.04 .
