### PR TITLE
Change ssl to be boolean type

### DIFF
--- a/library/mongodb_replication.py
+++ b/library/mongodb_replication.py
@@ -325,7 +325,7 @@ def main():
             host_name=dict(default='localhost'),
             host_port=dict(default='27017'),
             host_type=dict(default='replica', choices=['replica','arbiter']),
-            ssl=dict(default='false'),
+            ssl = dict(type='bool', default='false'),
             build_indexes = dict(type='bool', default='yes'),
             hidden = dict(type='bool', default='no'),
             priority = dict(default='1.0'),


### PR DESCRIPTION
If you set ssl to true, you get a failure to validate error. Something gets confused. Forcing it to be type:boolean makes it work.