### PR TITLE
add systemLog.logRotate option as configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,7 @@ mongodb_storage_prealloc: true                   # Enable data file preallocatio
 ## If you specify 'file', you must also specify mongodb_systemlog_path.
 mongodb_systemlog_destination: "file"
 mongodb_systemlog_logappend: true                                        # Append to logpath instead of over-writing
+mongodb_systemlog_logrotate: "rename"                                    # Logrotation behavior
 mongodb_systemlog_path: /var/log/mongodb/{{ mongodb_daemon_name }}.log   # Log file to send write to instead of stdout
 
 ## replication Options

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -50,6 +50,7 @@ systemLog:
   destination: {{ mongodb_systemlog_destination }}
   {% if mongodb_systemlog_destination == 'file' -%}
   logAppend: {{ mongodb_systemlog_logappend | to_nice_json }}
+  logRotate: {{ mongodb_systemlog_logrotate }}
   path: {{ mongodb_systemlog_path }}
   {% endif %}
 

--- a/templates/mongod_init.conf.j2
+++ b/templates/mongod_init.conf.j2
@@ -38,5 +38,6 @@ systemLog:
   destination: {{ mongodb_systemlog_destination }}
   {% if mongodb_systemlog_destination == 'file' -%}
   logAppend: {{ mongodb_systemlog_logappend | to_nice_json }}
+  logRotate: {{ mongodb_systemlog_logrotate }}
   path: {{ mongodb_systemlog_path }}
   {% endif -%}


### PR DESCRIPTION
This should be configurable to be set to `reopen` when normal external log rotate is used.
