### PR TITLE
ignore empty mongodb repository gpgkey settings

### DIFF
--- a/templates/mongodb.repo.j2
+++ b/templates/mongodb.repo.j2
@@ -1,8 +1,10 @@
 [mongodb-org-{{ mongodb_version }}]
 name=MongoDB {{ mongodb_version }} Repository
 baseurl={{ mongodb_repository[item] }}
-gpgcheck={{ mongodb_repository_gpgkey[item] is defined | ternary(1,0) }}
-{% if mongodb_repository_gpgkey[item] is defined %}
+{% if mongodb_repository_gpgkey[item] is defined and mongodb_repository_gpgkey[item] != '' %}
+gpgcheck=1
 gpgkey={{ mongodb_repository_gpgkey[item] }}
+{% else %}
+gpgcheck=0
 {% endif %}
 enabled=1


### PR DESCRIPTION
When overriding mongodb repository settings, ignore empty gpgkey entries. (needed e.g. when using `merge_behavior=hash`).