### PR TITLE
Allow user to choose PyMongo version when using pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ mongodb_package: mongodb-org
 mongodb_version: "3.6"
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
+mongodb_pymongo_pip_version:                     # Choose PyMong version to install from pip. If not set use latest
 mongodb_user_update_password: "on_create"        # MongoDB user password update default policy
 mongodb_manage_service: true
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ mongodb_package: mongodb-org
 mongodb_version: "3.6"
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
-mongodb_pymongo_pip_version:                     # Choose PyMong version to install from pip. If not set use latest
+mongodb_pymongo_pip_version: 3.6.1               # Choose PyMong version to install from pip. If not set use latest
 mongodb_user_update_password: "on_create"        # MongoDB user password update default policy
 mongodb_manage_service: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ mongodb_apt_key_id:
   "3.6": "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
+mongodb_pymongo_pip_version: 3.6.1
 
 mongodb_user_update_password: "on_create"        # MongoDB user password update default policy
 mongodb_manage_service: true

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -68,5 +68,8 @@
   when: mongodb_pymongo_from_pip
 
 - name: Install PyMongo from PIP
-  pip: name=pymongo state=latest
+  pip:
+    name: pymongo
+    state: "{{ mongodb_pymongo_pip_version is defined | ternary('present', 'latest') }}"
+    version: "{{ mongodb_pymongo_pip_version | default(omit) }}"
   when: mongodb_pymongo_from_pip

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -42,5 +42,6 @@
 - name: Install PyMongo from PIP
   pip:
     name: pymongo
-    state: latest
+    state: "{{ mongodb_pymongo_pip_version is defined | ternary('present', 'latest') }}"
+    version: "{{ mongodb_pymongo_pip_version | default(omit) }}"
   when: mongodb_pymongo_from_pip


### PR DESCRIPTION
Due to issue #113 I created a new variable `mongodb_pymongo_pip_version` to allow users to choose which version to get from pip. `3.6.1` works fine