### PR TITLE
Remove unneeded systemd reload task

### DIFF
--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -49,10 +49,6 @@
   when: mongodb_is_systemd
   notify: reload systemd
 
-- name: reload systemd
-  shell: systemctl daemon-reload
-  when: mongodb_is_systemd and mongodb_manage_service
-
 - meta: flush_handlers
   when: mongodb_is_systemd
 


### PR DESCRIPTION
This task has already been implemented as a handler, so no need to have it here, it breaks idempotence.