### PR TITLE
Added ssl config support in config template

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,9 @@ mongodb_net_http_enabled: false                  # Enable http interface
 mongodb_net_ipv6: false                          # Enable IPv6 support (disabled by default)
 mongodb_net_maxconns: 65536                      # Max number of simultaneous connections
 mongodb_net_port: 27017                          # Specify port number
+mongodb_net_ssl: disabled                        # Enable or disable ssl connections
+mongodb_net_ssl_mode:                            # Set the ssl mode (RequireSSL / PreferSSL / AllowSSL / disabled)
+mongodb_net_ssl_pemfile:                         # Location of the pemfile to use for ssl
 
 ## processManagement Options
 # Fork server process

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -9,6 +9,11 @@ net:
   ipv6: {{ mongodb_net_ipv6 | to_nice_json }}
   maxIncomingConnections: {{ mongodb_net_maxconns }}
   port: {{ mongodb_net_port }}
+  {% if mongodb_net_ssl_pemfile is defined and mongodb_net_ssl_mode is defined and mongodb_net_ssl == 'enabled' -%}
+  ssl:
+    mode: {{ mongodb_net_ssl_mode }}
+    PEMKeyFile: {{ mongodb_net_ssl_pemfile }}.pem
+  {% endif %}
 
 processManagement:
   fork: {{ mongodb_processmanagement_fork | to_nice_json}}


### PR DESCRIPTION
We needed a mongodb replication cluster with internode ssl , this is a quick way to add it 