### PR TITLE
Add "DirectoryPerDB" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ mongodb_security_keyfile: /etc/mongodb-keyfile   # Specify path to keyfile with 
 
 ## storage Options
 mongodb_storage_dbpath: /data/db                 # Directory for datafiles
+mongodb_storage_dirperdb: false                  # Use one directory per DB
+
 # The storage engine for the mongod database. Available values:
 # 'mmapv1', 'wiredTiger'
 mongodb_storage_engine: "{{ 'mmapv1' if mongodb_version[0:3] == '3.0' else 'wiredTiger' }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,8 @@ mongodb_security_keyfile: /etc/mongodb-keyfile   # Specify path to keyfile with 
 
 ## storage Options
 mongodb_storage_dbpath: /data/db                 # Directory for datafiles
+mongodb_storage_dirperdb: false                  # Use one directory per DB
+
 # The storage engine for the mongod database. Available values:
 # 'mmapv1', 'wiredTiger'
 mongodb_storage_engine: "wiredTiger"

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -38,7 +38,7 @@ security:
 
 storage:
   dbPath: {{ mongodb_storage_dbpath }}
-  directoryPerDB: {{ mongodb_storage_dirperdb }}
+  directoryPerDB: {{ mongodb_storage_dirperdb | to_nice_json }}
   {% if mongodb_major_version | version_compare("3.0", ">=") -%}
   engine: {{ mongodb_storage_engine }}
   {% endif -%}

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -38,6 +38,7 @@ security:
 
 storage:
   dbPath: {{ mongodb_storage_dbpath }}
+  directoryPerDB: {{ mongodb_storage_dirperdb }}
   {% if mongodb_major_version | version_compare("3.0", ">=") -%}
   engine: {{ mongodb_storage_engine }}
   {% endif -%}

--- a/templates/mongod_init.conf.j2
+++ b/templates/mongod_init.conf.j2
@@ -21,7 +21,7 @@ security:
 
 storage:
   dbPath: {{ mongodb_storage_dbpath }}
-  directoryPerDB: {{ mongodb_storage_dirperdb }}
+  directoryPerDB: {{ mongodb_storage_dirperdb | to_nice_json }}
   {% if mongodb_major_version | version_compare("3.0", ">=") -%}
   engine: {{ mongodb_storage_engine }}
   {% endif -%}

--- a/templates/mongod_init.conf.j2
+++ b/templates/mongod_init.conf.j2
@@ -21,6 +21,7 @@ security:
 
 storage:
   dbPath: {{ mongodb_storage_dbpath }}
+  directoryPerDB: {{ mongodb_storage_dirperdb }}
   {% if mongodb_major_version | version_compare("3.0", ">=") -%}
   engine: {{ mongodb_storage_engine }}
   {% endif -%}


### PR DESCRIPTION
Hello...

I had the specific need to set up a Mongo Cluster with the DirectorPerDB option set to true. I added the parameter to the defaults (default to false as per Mongo Default) and unconditionally added the resulting output to mongod_init.conf.j2 and mongod.conf.j2.

It could be argued to make the inclusion of the parameter in the config files conditional on it being set to true, but I think that explicit is better (and simpler).

Received minimal testing by deploying with the option set to true and to false on a newly deployed VM and it does, what it is supposed to.

Also added a line to the README.md.
Feedback or merge appreciated :-)

kind regards,
Patrick
