### PR TITLE
Sytemd daemon reload duplication

### DIFF
--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -58,10 +58,6 @@
   when: mongodb_is_systemd
   notify: reload systemd
 
-- name: reload systemd
-  shell: systemctl daemon-reload
-  when: mongodb_is_systemd and mongodb_manage_service
-
 - meta: flush_handlers
   when: mongodb_is_systemd
 


### PR DESCRIPTION
systemd daemon reload is already handled by a handler. The task in question is causing systemd reload on every play which is bad.