### PR TITLE
Add a variable to disable transparent hugepages

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ mongodb_pymongo_pip_version: 3.6.1               # Choose PyMong version to inst
 mongodb_user_update_password: "on_create"        # MongoDB user password update default policy
 mongodb_manage_service: true
 
+# Disable transparent hugepages on systemd debian based installations
+mongodb_disable_transparent_hugepages: false
+
 mongodb_user: "{{ 'mongod' if ('RedHat' == ansible_os_family) else 'mongodb' }}"
 mongodb_uid:
 mongodb_gid:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ mongodb_pymongo_pip_version: 3.6.1
 mongodb_user_update_password: "on_create"        # MongoDB user password update default policy
 mongodb_manage_service: true
 
+mongodb_disable_transparent_hugepages: false
+
 mongodb_user: "{{ 'mongod' if ('RedHat' == ansible_os_family) else 'mongodb' }}"
 mongodb_uid:
 mongodb_gid:

--- a/files/disable-transparent-hugepages.init
+++ b/files/disable-transparent-hugepages.init
@@ -1,0 +1,10 @@
+[Unit]
+Description="Disable transparent hugepages"
+Before=mongodb.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/disable-transparent-hugepages.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/files/disable-transparent-hugepages.sh
+++ b/files/disable-transparent-hugepages.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ -d /sys/kernel/mm/transparent_hugepage ]; then
+    thp_path=/sys/kernel/mm/transparent_hugepage
+else
+    return 0
+fi
+
+echo 'never' > ${thp_path}/enabled
+echo 'never' > ${thp_path}/defrag

--- a/tasks/disable_transparent_hugepages.yml
+++ b/tasks/disable_transparent_hugepages.yml
@@ -1,0 +1,22 @@
+- name: Install disable transparent hugepages helper
+  copy:
+    src: disable-transparent-hugepages.sh
+    dest: /opt/disable-transparent-hugepages.sh
+    owner: root
+    group: root
+    mode: 0700
+
+- name: Create disable transparent hugepages init file
+  copy:
+    src: disable-transparent-hugepages.init
+    dest: /etc/systemd/system/disable-transparent-hugepages.init
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Enable init file
+  systemd:
+    name: disable-transparent-hugepages
+    daemon-reload: yes
+    enabled: yes
+    state: started

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -11,6 +11,12 @@
     mongodb_is_systemd: "{{ sbin_init.stat.islnk is defined and sbin_init.stat.islnk }}"
     mongodb_major_version: "{{ mongodb_version[0:3] }}"
 
+- name: Disable transparent huge pages on systemd systems
+  include_tasks: disable_transparent_hugepages.yml
+  when:
+    - mongodb_disable_transparent_hugepages
+    - mongodb_is_systemd
+
 - name: Add APT key
   apt_key:
     keyserver: "{{ mongodb_apt_keyserver }}"


### PR DESCRIPTION
This PR adds a variable to allow transparent hugepages deactivation using a systemd service.

I guess it can also work on redhat based system since deactivate script came from mongodb redhat documentation: https://docs.mongodb.com/manual/tutorial/transparent-huge-pages/