### PR TITLE
Set selinux type on data directory

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -41,6 +41,7 @@
     path: "{{ mongodb_storage_dbpath }}"
     state: directory
     owner: "{{ mongodb_user }}"
+    setype: 'mongod_var_lib_t'
     recurse: yes
 
 - name: Configure mongodb


### PR DESCRIPTION
When changing the default data directory path on systems with SELinux, we must also set the SELinux type on that directory.