### PR TITLE
BB-212 Add ability to add more roles to admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ mongodb_keyfile_content: |
 # names and passwords for administrative users
 mongodb_user_admin_name: siteUserAdmin
 mongodb_user_admin_password: passw0rd
+# Extra roles to add for administrative users
+mongodb_user_admin_roles: 
+    - db: admin
+      role: dbAdminAnyDatabase
 
 mongodb_root_admin_name: siteRootAdmin
 mongodb_root_admin_password: passw0rd

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,6 +96,9 @@ mongodb_keyfile_content: |
 # names and passwords for administrative users
 mongodb_user_admin_name: siteUserAdmin
 mongodb_user_admin_password: passw0rd
+mongodb_user_admin_roles:
+    - role: userAdminAnyDatabase
+      db: admin
 
 mongodb_root_admin_name: siteRootAdmin
 mongodb_root_admin_password: passw0rd

--- a/tasks/auth_initialization.yml
+++ b/tasks/auth_initialization.yml
@@ -31,7 +31,7 @@
     - {
       name: "{{ mongodb_user_admin_name }}",
       password: "{{ mongodb_user_admin_password }}",
-      roles: "userAdminAnyDatabase"
+      roles: "{{ [{'db': 'admin', 'role':'userAdminAnyDatabase'}] + ( mongodb_user_admin_roles | default([]) )}}"
       }
   no_log: true
 

--- a/tasks/auth_initialization.yml
+++ b/tasks/auth_initialization.yml
@@ -31,7 +31,7 @@
     - {
       name: "{{ mongodb_user_admin_name }}",
       password: "{{ mongodb_user_admin_password }}",
-      roles: "{{ [{'db': 'admin', 'role':'userAdminAnyDatabase'}] + ( mongodb_user_admin_roles | default([]) )}}"
+      roles: "{{ mongodb_user_admin_roles }}"
       }
   no_log: true
 


### PR DESCRIPTION
By default an admin user is created with `userAdminAnyDatabase`. Sometimes there's a need to add more roles to this user. For instance, I would like to also add `dbAdminAnyDatabase` role to that user since that would also give the user permission to drop databases.
This PR changes the way that roles are added to the admin user from a single, hard-coded, role to a list of dictionaries. Changing the value to a list of dictionaries gives us the ability to always have `userAdminAnyDatabase` as a default role and allow whomever uses this ansible role to extend those values to add other mongo db roles. This is valid as per the [ansible documentation](https://docs.ansible.com/ansible/latest/modules/mongodb_user_module.html) 