### PR TITLE
Require backup user password to be changed on production

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Required vars to change on production:
 ```yaml
 mongodb_user_admin_password
 mongodb_root_admin_password
-mongodb_root_backup_name
+mongodb_root_backup_password
 
 # if you use replication and authorization
 mongodb_security_keyfile


### PR DESCRIPTION
Currently backup user password is not specified in the list of variables required to be changed on production. This may result some users having insecure password `passw0rd` for a backup user in their production environment.