### PR TITLE
Apt update cache before installing mogodb

### DIFF
--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -55,6 +55,7 @@
       - "{{mongodb_package}}"
       - numactl
     state: present
+    update_cache: yes
 
 - name: Add systemd configuration if present
   copy: src=mongodb.service dest=/lib/systemd/system/mongodb.service owner=root group=root mode=0640


### PR DESCRIPTION
Fix "No package matching 'mongodb' is available" error