### PR TITLE
Add variable to customize mongodb package state

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 
 mongodb_package: mongodb-org
+mongodb_package_state: present
 mongodb_version: "3.6"
 mongodb_apt_keyserver: keyserver.ubuntu.com
 mongodb_apt_key_id:

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -55,7 +55,7 @@
     name:
       - "{{mongodb_package}}"
       - numactl
-    state: present
+    state: "{{ mongodb_package_state }}"
     update_cache: yes
 
 - name: Add systemd configuration if present


### PR DESCRIPTION
Allows to easily upgrade MongoDB by overriding the `mongodb_package_state` variable.

Example:

```
ansible-playbook -i inventory site.yml -e mongodb_package_state=latest
```