### PR TITLE
Allow more options in replication params

### DIFF
--- a/tasks/replication.yml
+++ b/tasks/replication.yml
@@ -2,6 +2,7 @@
 
 - name: Replication configuration
   mongodb_replication:
+    build_indexes: "{{ item.build_indexes|default(omit) }}"
     login_host: "{{ mongodb_login_host|default('localhost') }}"
     login_port: "{{ mongodb_login_port|default(27017) }}"
     login_user: "{{ mongodb_root_admin_name }}"
@@ -12,12 +13,14 @@
     host_type: "{{ item.host_type|default('replica') }}"
     hidden: "{{ item.hidden|default(false) }}"
     priority: "{{ item.priority|default(1.0) }}"
+    votes: "{{ item.votes|default(omit) }}"
   when: mongodb_security_authorization == 'enabled'
   with_items:
     - "{{ mongodb_replication_params|default([]) }}"
 
 - name: Replication configuration without auth
   mongodb_replication:
+    build_indexes: "{{ item.build_indexes|default(omit) }}"
     login_host: "{{ mongodb_login_host|default('localhost') }}"
     login_port: "{{ mongodb_login_port|default(27017) }}"
     replica_set: "{{ mongodb_replication_replset }}"
@@ -26,6 +29,7 @@
     host_type: "{{ item.host_type|default('replica') }}"
     hidden: "{{ item.hidden|default(false) }}"
     priority: "{{ item.priority|default(1.0) }}"
+    votes: "{{ item.votes|default(omit) }}"
   when: mongodb_security_authorization == 'disabled'
   with_items:
     - "{{ mongodb_replication_params|default([]) }}"

--- a/tasks/replication_init_auth.yml
+++ b/tasks/replication_init_auth.yml
@@ -1,6 +1,7 @@
 ---
 - name: Replication configuration | 1st Pt.
   mongodb_replication:
+    build_indexes: "{{ item.build_indexes|default(omit) }}"
     login_host: "{{ mongodb_login_host|default('localhost') }}"
     login_port: "{{ mongodb_net_port|default(27017) }}"
     login_user: "{{ mongodb_root_admin_name }}"
@@ -11,6 +12,7 @@
     host_type: "{{ item.host_type|default('replica') }}"
     hidden: "{{ item.hidden|default(false) }}"
     priority: "{{ item.priority|default(1.0) }}"
+    votes: "{{ item.votes|default(omit) }}"
   with_items:
     - "{{ mongodb_replication_params|default([]) }}"
   register: mongodb_replica_init
@@ -21,6 +23,7 @@
 
 - name: Replication configuration | 2nd Pt
   mongodb_replication:
+    build_indexes: "{{ item.build_indexes|default(omit) }}"
     login_host: "{{ mongodb_login_host|default('localhost') }}"
     login_port: "{{ mongodb_net_port|default(27017) }}"
     login_user: "{{ mongodb_root_admin_name }}"
@@ -31,6 +34,7 @@
     host_type: "{{ item.host_type|default('replica') }}"
     hidden: "{{ item.hidden|default(false) }}"
     priority: "{{ item.priority|default(1.0) }}"
+    votes: "{{ item.votes|default(omit) }}"
   when: mongodb_replica_init|failed
   with_items:
     - "{{ mongodb_replication_params|default([]) }}"


### PR DESCRIPTION
Add `build_indexes` and `votes` options of `mongodb_replication` module. If not provided, options are omitted so this PR is backward compatible.

Use case:

Hidden member with no votes and no index built:
```
mongodb_replication_params:
  - host_name: "mongodb-slave.internal.domain"
    build_indexes: false
    hidden: true
    priority: 0
    votes: 0
```