### PR TITLE
Fix systemd service file permissions

### DIFF
--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -59,7 +59,7 @@
     update_cache: yes
 
 - name: Add systemd configuration if present
-  copy: src=mongodb.service dest=/lib/systemd/system/mongodb.service owner=root group=root mode=0640
+  copy: src=mongodb.service dest=/lib/systemd/system/mongodb.service owner=root group=root mode=0644
   when: mongodb_is_systemd
 
 - name: Add symlink for systemd


### PR DESCRIPTION
Change permissions of `/lib/systemd/system/mongodb.service` from 640 to 644 to avoid warning  message in syslog during `systemctl daemon-reload`.

```
May 15 14:35:24 web01 systemd[1]: Configuration file /lib/systemd/system/mongodb.service is marked world-inaccessible. This has no effect as configuration data is accessible via APIs without restrictions. Proceeding anyway.
```