### PR TITLE
Mongodb package name fix for ubuntu 18.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ env:
     DISTRIBUTION=ubuntu
     DIST_VERSION=18_04-builded
     MONGODB_VERSION=4.0
-    MONGODB_PACKAGE=mongodb
+    MONGODB_PACKAGE=mongodb-org
   - >
     DISTRIBUTION=ubuntu
     DIST_VERSION=18_04-builded
     MONGODB_VERSION=3.6
-    MONGODB_PACKAGE=mongodb
+    MONGODB_PACKAGE=mongodb-org
   - >
     DISTRIBUTION=ubuntu
     DIST_VERSION=16_04-builded
@@ -49,7 +49,7 @@ env:
     DISTRIBUTION=debian
     DIST_VERSION=9-builded
     MONGODB_VERSION=3.6
-    MONGODB_PACKAGE=mongodb
+    MONGODB_PACKAGE=mongodb-org
   - >
     DISTRIBUTION=debian
     DIST_VERSION=8-builded

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     DISTRIBUTION=ubuntu
     DIST_VERSION=18_04-builded
     MONGODB_VERSION=3.6
-    MONGODB_PACKAGE=mongodb-org
+    MONGODB_PACKAGE=mongodb
   - >
     DISTRIBUTION=ubuntu
     DIST_VERSION=16_04-builded

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -29,14 +29,16 @@
   when: (mongodb_package == 'mongodb-org' and
         (mongodb_version is not defined
          or mongodb_repository[mongodb_major_version] is not defined
-         or (mongodb_version != '3.6' and mongodb_version != '4.0')) 
+         or (mongodb_version != '3.6' and mongodb_version != '4.0'))
          and (ansible_distribution_release == 'stretch' and ansible_distribution_release == 'jessie'))
 
 - name: Fail when used wrong mongodb_version variable with Ubuntu 18.04
   fail:
     msg: "mongodb_version variable should be '4.0' or else mongodb_package should be 'mongodb' for Ubuntu 18.04"
-  when: (mongodb_package == 'mongodb-org' and mongodb_version != '4.0')
-        and ansible_distribution_release == "bionic")
+  when:
+    - mongodb_package == 'mongodb-org'
+    - mongodb_version != '4.0'
+    - ansible_distribution_release == "bionic"
 
 - name: Fail when used wrong mongodb_version variable
   fail:

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -34,8 +34,8 @@
 
 - name: Fail when used wrong mongodb_version variable with Ubuntu 18.04
   fail:
-    msg: "mongodb_version variable should be '3.6' or '4.0' and mongodb_package should be 'mongodb-org' for Ubuntu 18.04"
-  when: ((mongodb_package != 'mongodb-org' or (mongodb_version != '3.6' and mongodb_version != '4.0'))
+    msg: "mongodb_version variable should be '4.0' or else mongodb_package should be 'mongodb' for Ubuntu 18.04"
+  when: (mongodb_package == 'mongodb-org' and mongodb_version != '4.0')
         and ansible_distribution_release == "bionic")
 
 - name: Fail when used wrong mongodb_version variable

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -34,8 +34,8 @@
 
 - name: Fail when used wrong mongodb_version variable with Ubuntu 18.04
   fail:
-    msg: "mongodb_version variable should be '3.6' or '4.0' and mongodb_package should be 'mongodb' for Ubuntu 18.04"
-  when: ((mongodb_package == 'mongodb-org' or (mongodb_version != '3.6' and mongodb_version != '4.0'))
+    msg: "mongodb_version variable should be '3.6' or '4.0' and mongodb_package should be 'mongodb-org' for Ubuntu 18.04"
+  when: ((mongodb_package != 'mongodb-org' or (mongodb_version != '3.6' and mongodb_version != '4.0'))
         and ansible_distribution_release == "bionic")
 
 - name: Fail when used wrong mongodb_version variable

--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -1,8 +1,8 @@
 ---
 
-image_name: "ubuntu-upstart:14.04"
+image_name: "ubuntu-upstart:18.04"
 mongodb_package: mongodb-org
-mongodb_version: "3.6"
+mongodb_version: "4.0"
 mongodb_storage_dbpath: /var/lib/mongodb
 mongodb_net_bindip: 0.0.0.0
 mongodb_login_host: "{{ hostvars[groups['mongo_master'][0]].ansible_default_ipv4.address }}"


### PR DESCRIPTION
- mongodb package name for 18.04 is 'mongodb-org'
- package name 'mongodb' will install mongodb
  from ubuntu repo which is 3.6 currently and is
  not a recommended way.