### PR TITLE
Mongodb idempotency fix

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,7 +13,8 @@
   when: mongodb_manage_service
 
 - name: reload systemd
-  shell: systemctl daemon-reload
+  systemd:
+    daemon_reload: yes
   when: mongodb_is_systemd and mongodb_manage_service
 
 - name: restart sysfsutils

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -53,7 +53,7 @@
   when: mongodb_package == 'mongodb-org'
 
 - name: Install MongoDB package
-  apt: 
+  apt:
     name:
       - "{{mongodb_package}}"
       - numactl
@@ -68,10 +68,6 @@
   file: src=/lib/systemd/system/mongodb.service dest=/etc/systemd/system/multi-user.target.wants/mongodb.service state=link
   when: mongodb_is_systemd
   notify: reload systemd
-
-- name: reload systemd
-  shell: systemctl daemon-reload
-  when: mongodb_is_systemd and mongodb_manage_service
 
 - block:
    - meta: flush_handlers


### PR DESCRIPTION
- systemd daemon-reload not needed twice
- systemd daemon-reload via systemd module instead of shell