### PR TITLE
Add option to configure free monitoring

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,7 +71,7 @@ mongodb_systemlog_path: /var/log/mongodb/{{ mongodb_daemon_name }}.log   # Log f
 mongodb_operation_profiling_slow_op_threshold_ms: 100
 mongodb_operation_profiling_mode: "off"
 
-## cloud options
+## cloud options (MongoDB >= 4.0)
 mongodb_cloud_monitoring_free_state: "runtime"
 
 ## replication Options

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,9 @@ mongodb_systemlog_path: /var/log/mongodb/{{ mongodb_daemon_name }}.log   # Log f
 mongodb_operation_profiling_slow_op_threshold_ms: 100
 mongodb_operation_profiling_mode: "off"
 
+## cloud options
+mongodb_cloud_monitoring_free_state: "runtime"
+
 ## replication Options
 mongodb_replication_replset: ""                   # Enable replication
 mongodb_replication_replindexprefetch: "all"      # specify index prefetching behavior (if secondary) [none|_id_only|all]

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -71,10 +71,12 @@ operationProfiling:
   slowOpThresholdMs: {{ mongodb_operation_profiling_slow_op_threshold_ms }}
   mode: {{ mongodb_operation_profiling_mode }}
 
+{% if mongodb_major_version is version("4.0", ">=") -%}
 cloud:
   monitoring:
     free:
       state: {{ mongodb_cloud_monitoring_free_state }}
+{% endif -%}
 
 {% if mongodb_set_parameters -%}
 setParameter:

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -71,6 +71,11 @@ operationProfiling:
   slowOpThresholdMs: {{ mongodb_operation_profiling_slow_op_threshold_ms }}
   mode: {{ mongodb_operation_profiling_mode }}
 
+cloud:
+  monitoring:
+    free:
+      state: {{ mongodb_cloud_monitoring_free_state }}
+
 {% if mongodb_set_parameters -%}
 setParameter:
   {% for key, value in mongodb_set_parameters.items() -%}


### PR DESCRIPTION
Add `mongodb_cloud_monitoring_free_state` variable which controls `cloud.monitoring.free.state` in `/etc/mongod.conf`.

This option is described in https://docs.mongodb.com/manual/reference/configuration-options/#cloud-options.

By setting `mongodb_cloud_monitoring_free_state` to `off` you get rid of the annoying message added in MongoDB shell 4.0.X:
```
---
Enable MongoDB's free cloud-based monitoring service, which will then receive and display
metrics about your deployment (disk utilization, CPU, operation statistics, etc).

The monitoring data will be available on a MongoDB website with a unique URL accessible to you
and anyone you share the URL with. MongoDB may use this information to make product
improvements and to suggest MongoDB products and deployment options to you.

To enable free monitoring, run the following command: db.enableFreeMonitoring()
To permanently disable this reminder, run the following command: db.disableFreeMonitoring()
---
```