### PR TITLE
Ensure the systemd file is created under the correct name on Debian/Ubuntu

### DIFF
--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -59,13 +59,13 @@
     state: present
 
 - name: Add systemd configuration if present
-  copy: src=mongodb.service dest=/lib/systemd/system/mongodb.service owner=root group=root mode=0644
+  copy: src=mongodb.service dest=/lib/systemd/system/{{mongodb_daemon_name}}.service owner=root group=root mode=0644
   when: ansible_service_mgr == "systemd"
   notify:
     - reload systemd
 
 - name: Add symlink for systemd
-  file: src=/lib/systemd/system/mongodb.service dest=/etc/systemd/system/multi-user.target.wants/mongodb.service state=link
+  file: src=/lib/systemd/system/{{mongodb_daemon_name}}.service dest=/etc/systemd/system/multi-user.target.wants/{{mongodb_daemon_name}}.service state=link
   when: ansible_service_mgr == "systemd"
   notify:
     - reload systemd


### PR DESCRIPTION
When installing mongodb-org packages on Debian/Ubuntu the daemon name is set to "mongod" but the .service file is unconditionally installed as "mongodb.service". This PR ensures, that the systemd file (and the accompanying symlink) are installed as "mongodb_dameon_name.service". Otherwise installation fails with 
fatal: [tmongo-02]: FAILED! => {"changed": false, "msg": "Could not find the requested service mongod: host"}

for every host, as the handler tries to restart mongod, but systemd only sees mongodb.

Minimally tested against Ubuntu 16.04/Mongo 3.4.