### PR TITLE
Add setuptools install

### DIFF
--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -82,6 +82,12 @@
       - python-pip
   when: mongodb_pymongo_from_pip | bool
 
+- name: Install setuptools (required for ansible 2.7+)
+  apt:
+    pkg:
+      - python-setuptools
+  when: mongodb_pymongo_from_pip | bool
+
 - name: Install PyMongo from PIP
   pip:
     name: pymongo


### PR DESCRIPTION
Since ansible 2.7+, it is appearently required to have `setuptools` installed on the target hosts to use the `pip` module (see [this issue](https://github.com/ansible/ansible/issues/47361)).

Note: I tested only on debian 9, but I assume the `python-setuptools` package is available in other debians...