### PR TITLE
Make NUMA optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ mongodb_manage_systemd_unit: true
 # Disable transparent hugepages on systemd debian based installations
 mongodb_disable_transparent_hugepages: false
 
+# You can enable or disable NUMA support
+mongodb_use_numa: true
+
 mongodb_user: "{{ 'mongod' if ('RedHat' == ansible_os_family) else 'mongodb' }}"
 mongodb_uid:
 mongodb_gid:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,8 @@ mongodb_systemd_unit_limit_nproc: 64000
 
 mongodb_disable_transparent_hugepages: false
 
+mongodb_use_numa: true
+
 mongodb_user: "{{ 'mongod' if ('RedHat' == ansible_os_family) else 'mongodb' }}"
 mongodb_uid:
 mongodb_gid:

--- a/tasks/install.amazon.yml
+++ b/tasks/install.amazon.yml
@@ -24,6 +24,7 @@
     name: numactl
     state: present
     lock_timeout: "{{ yum_lock_timeout }}"
+  when: mongodb_use_numa | bool
 
 - name: Install PyMongo package
   yum:

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -57,6 +57,7 @@
   apt:
     name: numactl
     state: present
+  when: mongodb_use_numa | bool
 
 - name: Add systemd configuration if present
   template:

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -30,6 +30,7 @@
     name: numactl
     state: present
     lock_timeout: "{{ yum_lock_timeout }}"
+  when: mongodb_use_numa | bool
 
 - name: Install PyMongo package
   yum:

--- a/templates/mongodb.service.j2
+++ b/templates/mongodb.service.j2
@@ -5,7 +5,11 @@ Documentation=man:mongod(1)
 
 [Service]
 User={{ mongodb_user }}
+{% if mongodb_use_numa | bool %}
 ExecStart=/usr/bin/numactl --interleave=all /usr/bin/mongod --config /etc/mongod.conf
+{% else %}
+ExecStart=/usr/bin/mongod --config /etc/mongod.conf
+{% endif %}
 # file size
 LimitFSIZE=infinity
 # cpu time


### PR DESCRIPTION
Hello,

Add a variable allowing to disable NUMA.
Default behaviour remains the same as before (enabled).
My use case is NUMA is not available inside a Docker container run on Github Actions.