### PR TITLE
skip yum installation when running check mode

### DIFF
--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -24,6 +24,7 @@
     name: "{{ mongodb_package }}{% if (mongodb_version | length > 3) %}={{ mongodb_version }}{% endif %}"
     state: "{{ mongodb_package_state }}"
     lock_timeout: "{{ yum_lock_timeout }}"
+  when: not ansible_check_mode
 
 - name: Install numactl package
   yum:

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -46,7 +46,8 @@
       - python-devel
       - python-pip
     lock_timeout: "{{ yum_lock_timeout }}"
-  when: mongodb_pymongo_from_pip | bool
+  when: (mongodb_pymongo_from_pip | bool) or
+        (not ansible_check_mode)
 
 - name: Install PyMongo from PIP
   pip:


### PR DESCRIPTION
This role helps me a lot.

I faced one problem when running ansible check mode at first time like following on CentOS.
```
TTASK [undergreen.mongodb : Install MongoDB package] *******************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "No package matching 'mongodb-org' found available, installed or updated", "rc": 126, "results": ["No package matching 'mongodb-org' found available, installed or updated"]}
```
But actual run can succeed.
So it's probably better to skip it when running check mode.