### PR TITLE
Added systemd template service for Debian

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,6 +85,7 @@ mongodb_cloud_monitoring_free_state: "runtime"
 mongodb_replication_replset: ""                   # Enable replication
 mongodb_replication_replindexprefetch: "all"      # specify index prefetching behavior (if secondary) [none|_id_only|all]
 mongodb_replication_oplogsize: 1024               # specifies a maximum size in megabytes for the replication operation log
+mongodb_enable_majority_read_concern: false
 
 # MMS Agent
 mongodb_mms_agent_pkg: https://cloud.mongodb.com/download/agent/monitoring/mongodb-mms-monitoring-agent_7.2.0.488-1_amd64.ubuntu1604.deb

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,7 +13,7 @@
 
 - name: mongodb restart
   service:
-    name: "{{ mongodb_daemon_name }}"
+    name: "{{ mongodb_daemon_name }}@{{ mongodb_instance_name }}"
     state: restarted
   when: mongodb_manage_service | bool
 

--- a/tasks/auth_initialization.yml
+++ b/tasks/auth_initialization.yml
@@ -2,7 +2,7 @@
 - name: Use different mongod.conf for auth initialization
   template:
     src: mongod_init.conf.j2
-    dest: /etc/mongod.conf
+    dest: "{{ mongodb_conf_file }}"
     owner: root
     group: root
     mode: 0644
@@ -64,7 +64,7 @@
 - name: Move back mongod.conf
   template:
     src: mongod.conf.j2
-    dest: /etc/mongod.conf
+    dest: "{{ mongodb_conf_file }}"
     owner: root
     group: root
     mode: 0644

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -74,7 +74,7 @@
 - name: Configure mongodb
   template:
     src: mongod.conf.j2
-    dest: /etc/mongod.conf
+    dest: "{{ mongodb_conf_file }}"
     backup: true
     owner: root
     group: root

--- a/tasks/disable_transparent_hugepages.yml
+++ b/tasks/disable_transparent_hugepages.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create disable transparent hugepages systemd service file
   template:
-    src: "{{ item }}"
+    src: "{{ template_name }}"
     dest: /etc/systemd/system/disable-transparent-hugepages.service
     owner: root
     group: root
@@ -9,6 +9,8 @@
   with_first_found:
     - "disable-transparent-hugepages.{{ ansible_distribution | lower }}.service.j2"
     - "disable-transparent-hugepages.{{ ansible_os_family | lower }}.service.j2"
+  loop_control:
+    loop_var: template_name
   notify: "run disable-transparent-hugepages"
   when:
     - ansible_service_mgr == "systemd"

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -62,7 +62,7 @@
 - name: Add systemd configuration if present
   template:
     src: mongodb.service.j2
-    dest: "/lib/systemd/system/{{mongodb_daemon_name}}.service"
+    dest: "/lib/systemd/system/{{ mongodb_daemon_name }}@.service"
     owner: root
     group: root
     mode: '0644'
@@ -74,8 +74,8 @@
 
 - name: Add symlink for systemd
   file:
-    src: "/lib/systemd/system/{{mongodb_daemon_name}}.service"
-    dest: "/etc/systemd/system/multi-user.target.wants/{{mongodb_daemon_name}}.service"
+    src: "/lib/systemd/system/{{ mongodb_daemon_name }}@.service"
+    dest: "/etc/systemd/system/multi-user.target.wants/{{mongodb_daemon_name}}@{{ mongodb_instance_name }}.service"
     state: link
   when:
     - ansible_service_mgr == "systemd"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -126,7 +126,7 @@
 
 - name: service started
   service:
-    name: "{{ mongodb_daemon_name }}"
+    name: "{{ mongodb_daemon_name }}@{{ mongodb_instance_name }}"
     state: started
     enabled: yes
 

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -25,6 +25,7 @@ processManagement:
 replication:
   oplogSizeMB: {{ mongodb_replication_oplogsize | int }}
   replSetName: {{ mongodb_replication_replset }}
+  enableMajorityReadConcern: {{ mongodb_enable_majority_read_concern | to_nice_json }}
   {% if mongodb_storage_engine == 'mmapv1' -%}
   secondaryIndexPrefetch: {{ mongodb_replication_replindexprefetch }}
   {% endif %}

--- a/templates/mongodb.service.j2
+++ b/templates/mongodb.service.j2
@@ -1,14 +1,14 @@
 # {{ ansible_managed }}
 [Unit]
-Description=An object/document-oriented database
+Description=MongoDB instance %i
 Documentation=man:mongod(1)
 
 [Service]
 User={{ mongodb_user }}
 {% if mongodb_use_numa | bool %}
-ExecStart=/usr/bin/numactl --interleave=all /usr/bin/mongod --config /etc/mongod.conf
+ExecStart=/usr/bin/numactl --interleave=all /usr/bin/mongod --config "/etc/{{ mongodb_daemon_name }}.%i.conf"
 {% else %}
-ExecStart=/usr/bin/mongod --config /etc/mongod.conf
+ExecStart=/usr/bin/mongod --config "/etc/{{ mongodb_daemon_name }}.%i.conf"
 {% endif %}
 # file size
 LimitFSIZE=infinity


### PR DESCRIPTION
1. systemd template service are useful to manage multiple mongodb services on the same host
2. removed a loop_control warning
3. managed conf variable enableMajorityReadConcern useful for MongoDB 4.2 replicaset
