### PR TITLE
explicitly use python2 for replication script

### DIFF
--- a/library/mongodb_replication.py
+++ b/library/mongodb_replication.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 # (c) 2015-2018, Sergei Antipov, 2GIS LLC
 #


### PR DESCRIPTION
Fixes #135 which is caused by systems which use Python 3 by default.