### PR TITLE
Use port 80 for Ubuntu keyserver

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 mongodb_package: mongodb-org
 mongodb_package_state: present
 mongodb_version: "4.4"
-mongodb_apt_keyserver: keyserver.ubuntu.com
+mongodb_apt_keyserver: 'hkp://keyserver.ubuntu.com:80'
 mongodb_apt_key_id:
   "3.6": "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
   "4.0": "9DA31620334BD75D9DCB49F368818C72E52529D4"


### PR DESCRIPTION
As if you are behind a firewall standard keyserver port 11371 may be filtered