### PR TITLE
repair linting warnings

### DIFF
--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -62,7 +62,7 @@
 - name: Add systemd configuration if present
   template:
     src: mongodb.service.j2
-    dest: "/lib/systemd/system/{{mongodb_daemon_name}}.service"
+    dest: "/lib/systemd/system/{{ mongodb_daemon_name }}.service"
     owner: root
     group: root
     mode: '0644'
@@ -74,8 +74,8 @@
 
 - name: Add symlink for systemd
   file:
-    src: "/lib/systemd/system/{{mongodb_daemon_name}}.service"
-    dest: "/etc/systemd/system/multi-user.target.wants/{{mongodb_daemon_name}}.service"
+    src: "/lib/systemd/system/{{ mongodb_daemon_name }}.service"
+    dest: "/etc/systemd/system/multi-user.target.wants/{{ mongodb_daemon_name }}.service"
     state: link
   when:
     - ansible_service_mgr == "systemd"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
   fail:
     msg: 'Set mongodb_net_ssl_mode is preferSSL or set valid hostname for mongodb_net_ssl_host!'
   when: ( mongodb_net_ssl_mode == 'requireSSL'
-          and mongodb_net_ssl_host == '' )
+          and mongodb_net_ssl_host | length > 0 )
 
 - name: Check value of variable mongodb_login_host
   fail:


### PR DESCRIPTION
There are a few linting reports here. I took a chance and fixed these.
```yml
[206] Variables should have spaces before and after: {{ var_name }}
tasks/install.debian.yml:65
    dest: "/lib/systemd/system/{{mongodb_daemon_name}}.service"

[206] Variables should have spaces before and after: {{ var_name }}
tasks/install.debian.yml:77
    src: "/lib/systemd/system/{{mongodb_daemon_name}}.service"

[206] Variables should have spaces before and after: {{ var_name }}
tasks/install.debian.yml:78
    dest: "/etc/systemd/system/multi-user.target.wants/{{mongodb_daemon_name}}.service"

[602] Don't compare to empty string
tasks/main.yml:7
          and mongodb_net_ssl_host == '' )
```