### PR TITLE
Fix PyMongo install on Ubuntu.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,8 @@ mongodb_apt_key_id:
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
 mongodb_pymongo_pip_version: 3.7.1
+mongodb_pymongo_package: python-pymongo
+mongodb_pip_package_name: python-pip
 
 mongodb_user_update_password: "on_create"        # MongoDB user password update default policy
 mongodb_manage_service: true

--- a/tasks/install.amazon.yml
+++ b/tasks/install.amazon.yml
@@ -28,7 +28,7 @@
 
 - name: Install PyMongo package
   yum:
-    name: python-pymongo
+    name: "{{ mongodb_pymongo_package }}"
     state: present
     lock_timeout: "{{ yum_lock_timeout }}"
   when: not mongodb_pymongo_from_pip
@@ -37,7 +37,7 @@
   yum:
     name:
       - python-devel
-      - python-pip
+      - "{{ mongodb_pip_package_name }}"
     lock_timeout: "{{ yum_lock_timeout }}"
   when: mongodb_pymongo_from_pip
 

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -8,7 +8,7 @@
     mongodb_pymongo_package: "python3-pymongo"
   when:
     - ansible_facts['distribution'] == "Ubuntu"
-    - ansible_facts['distribution_major_version'] >= "16"
+    - ansible_facts['distribution_major_version'] >= "20"
     - mongodb_pymongo_package == "python-pymongo"
 
 - name: Set Pip package name (Ubuntu)
@@ -16,7 +16,7 @@
     mongodb_pip_package_name: "python3-pip"
   when:
     - ansible_facts['distribution'] == "Ubuntu"
-    - ansible_facts['distribution_major_version'] >= "16"
+    - ansible_facts['distribution_major_version'] >= "20"
     - mongodb_pip_package_name == "python-pip"
 
 - name: Disable transparent huge pages on systemd systems

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -3,6 +3,22 @@
   set_fact:
     mongodb_major_version: "{{ mongodb_version[0:3] }}"
 
+- name: Set PyMongo package name (Ubuntu)
+  set_fact:
+    mongodb_pymongo_package: "python3-pymongo"
+  when:
+    - ansible_facts['distribution'] == "Ubuntu"
+    - ansible_facts['distribution_major_version'] >= "16"
+    - mongodb_pymongo_package == "python-pymongo"
+
+- name: Set Pip package name (Ubuntu)
+  set_fact:
+    mongodb_pip_package_name: "python3-pip"
+  when:
+    - ansible_facts['distribution'] == "Ubuntu"
+    - ansible_facts['distribution_major_version'] >= "16"
+    - mongodb_pip_package_name == "python-pip"
+
 - name: Disable transparent huge pages on systemd systems
   include_tasks: disable_transparent_hugepages.yml
   when:
@@ -85,14 +101,14 @@
 
 - name: Install PyMongo package
   apt:
-    name: python-pymongo
+    name: "{{ mongodb_pymongo_package }}"
   when: not mongodb_pymongo_from_pip
 
 - name: Install PIP
   apt:
     pkg:
       - python-dev
-      - python-pip
+      - "{{ mongodb_pip_package_name }}"
   when: mongodb_pymongo_from_pip | bool
 
 - name: Install setuptools (required for ansible 2.7+)

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -34,7 +34,7 @@
 
 - name: Install PyMongo package
   yum:
-    name: python-pymongo
+    name: "{{ mongodb_pymongo_package }}"
     state: present
     lock_timeout: "{{ yum_lock_timeout }}"
   when: not mongodb_pymongo_from_pip
@@ -43,7 +43,7 @@
   yum:
     name:
       - python-devel
-      - python-pip
+      - "{{ mongodb_pip_package_name }}"
     lock_timeout: "{{ yum_lock_timeout }}"
   when: mongodb_pymongo_from_pip | bool
 


### PR DESCRIPTION
This creates variables for the PyMongo and Pip package names so users can customize them as necessary. Also sets the default to the python3 package names for Ubuntu (In Focal Fossa, only the python3 package are available).

Fixes #211 and Fixes #224.