### PR TITLE
no_log = true for 'create oplog user with replicaset'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,7 +121,7 @@
   when: ( mongodb_replication_replset | length > 0
         and mongodb_security_authorization == 'enabled'
         and mongodb_master is defined and mongodb_master )
-  no_log: false
+  no_log: true
   tags: [mongodb]
 
 - name: service started


### PR DESCRIPTION
Task: "create oplog user with replicaset" (task/main, line 124) has "no_log: false" which exposes the oplog user and it's password during an ansible play.

changed no_log to true instead of false

Fixes #221 