### PR TITLE
mongodb_major_version needs to be a string

### DIFF
--- a/tasks/install.amazon.yml
+++ b/tasks/install.amazon.yml
@@ -1,7 +1,7 @@
 ---
 - name: Establish some role-related facts
   set_fact:
-    mongodb_major_version: "{{ mongodb_version[0:3] }}"
+    mongodb_major_version: "{{ mongodb_version[0:3] | string }}"
 
 - name: Add YUM repository
   template:

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Establish some role-related facts
   set_fact:
-    mongodb_major_version: "{{ mongodb_version[0:3] }}"
+    mongodb_major_version: "{{ mongodb_version[0:3] | string }}"
 
 - name: Disable transparent huge pages on systemd systems
   include_tasks: disable_transparent_hugepages.yml

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -2,7 +2,7 @@
 
 - name: Establish some role-related facts
   set_fact:
-    mongodb_major_version: "{{ mongodb_version[0:3] }}"
+    mongodb_major_version: "{{ mongodb_version[0:3] | string  }}"
 
 - name: Install EPEL release repository
   package:


### PR DESCRIPTION
In latest ansible versions the mongodb_major_version
becomes a float. So we need to explicitly make it a
string.