### PR TITLE
Allow fetching apt keys from url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,12 +3,18 @@
 mongodb_package: mongodb-org
 mongodb_package_state: present
 mongodb_version: "4.4"
+mongodb_apt_key_from_url: false
 mongodb_apt_keyserver: 'hkp://keyserver.ubuntu.com:80'
 mongodb_apt_key_id:
   "3.6": "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
   "4.0": "9DA31620334BD75D9DCB49F368818C72E52529D4"
   "4.2": "E162F504A20CDF15827F718D4B7C549A058F8B6B"
   "4.4": "20691eec35216c63caf66ce1656408e390cfb1f5"
+mongodb_apt_key_url:
+  "3.6": "https://www.mongodb.org/static/pgp/server-3.6.asc"
+  "4.0": "https://www.mongodb.org/static/pgp/server-4.0.asc"
+  "4.2": "https://www.mongodb.org/static/pgp/server-4.2.asc"
+  "4.4": "https://www.mongodb.org/static/pgp/server-4.4.asc"
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
 mongodb_pymongo_pip_version: 3.11.3

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -11,7 +11,8 @@
 
 - name: Add APT key
   apt_key:
-    keyserver: "{{ mongodb_apt_keyserver }}"
+    keyserver: "{{ mongodb_apt_keyserver if not mongodb_apt_key_from_url|bool else omit }}"
+    url: "{{ mongodb_apt_key_url[mongodb_major_version] if mongodb_apt_key_from_url|bool else omit }}"
     id: "{{ mongodb_apt_key_id[mongodb_major_version] }}"
   when: mongodb_package == 'mongodb-org'
 
@@ -44,7 +45,7 @@
   changed_when: false
   check_mode: no
   when: mongodb_use_numa | bool
-  
+
 - name: Don't use NUMA if it is unavailable on host
   set_fact:
     mongodb_use_numa: false


### PR DESCRIPTION
Apt-key doesn't work behind proxies when fetching from keyservers