### PR TITLE
Update support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MongoDB support matrix:
 
 | Distribution   | < MongoDB 3.4 |    MongoDB 3.6     |    MongoDB 4.0     |   MongoDB 4.2      |   MongoDB 4.4      |
 | -------------- | :-----------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| Ubuntu 16.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |
+| Ubuntu 16.04   |  :no_entry:   | :white_check_mark: | :x: | :x: |        :x:         |
 | Ubuntu 18.04   |  :no_entry:   | :white_check_mark: | :x: | :x: |        :x:         |
 | Ubuntu 20.04   |  :no_entry:   |        :x:         |        :x:         |        :x:         | :white_check_mark: |
 | Debian 9.x     |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |


### PR DESCRIPTION
After trying to install 4.0 on an 18.04 server I can confidentially say, it is not supported.

There are a lot of dependencies missing in the repos, starting with the correct libgcc-s1 version, going over libc-bin and now I'm struggling with getting python3.6-dev on the server after all those manual .deb file installations :(

I assume 4.2 won't be supported then as well