### PR TITLE
debian: allow automatic mongodb version upgrade

### DIFF
--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -34,9 +34,16 @@
 
 - name: Install MongoDB package
   apt:
-    name: "{{ mongodb_package }}{% if (mongodb_version | length > 3) %}={{ mongodb_version }}{% endif %}"
+    name: "{{ item }}{% if (mongodb_version | length > 3) %}={{ mongodb_version }}{% endif %}"
     state: "{{ mongodb_package_state }}"
     update_cache: true
+  with_items:
+    - "{{ mongodb_package }}"
+    - "{{ mongodb_package }}-database-tools-extra"
+    - "{{ mongodb_package }}-mongos"
+    - "{{ mongodb_package }}-server"
+    - "{{ mongodb_package }}-shell"
+    - "{{ mongodb_package }}-tools"
 
 - name: Check if NUMA is available on host
   command: "ls -1 /proc/1/numa_maps"

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -44,6 +44,7 @@
     - "{{ mongodb_package }}-server"
     - "{{ mongodb_package }}-shell"
     - "{{ mongodb_package }}-tools"
+  notify: mongodb restart
 
 - name: Check if NUMA is available on host
   command: "ls -1 /proc/1/numa_maps"


### PR DESCRIPTION
Hey everyone 👋 


If you do a version jump from 4.2 to 4.4 for example you need to manually upgrade most of the packages afterwards and restart mongoDB yourself.

This PR should allow us to do an automated version upgrade of MongoDB, by:
- Notifying the restart handler for mongodb on apt package change.
- Forcing all packages installed in a regular mongodb install to be installed (with specific version if thats wanted)

