### PR TITLE
Remove option  mongodb_cloud_monitoring_free_state

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,9 +84,6 @@ mongodb_systemlog_path: /var/log/mongodb/{{ mongodb_daemon_name }}.log   # Log f
 mongodb_operation_profiling_slow_op_threshold_ms: 100
 mongodb_operation_profiling_mode: "off"
 
-## cloud options (MongoDB >= 4.0)
-mongodb_cloud_monitoring_free_state: "runtime"
-
 ## replication Options
 mongodb_replication_replset: ""                   # Enable replication
 mongodb_replication_replindexprefetch: "all"      # specify index prefetching behavior (if secondary) [none|_id_only|all]

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -107,10 +107,6 @@ operationProfiling:
   {% endif %}
 
 {% if mongodb_major_version is version("4.0", ">=") -%}
-cloud:
-  monitoring:
-    free:
-      state: {{ mongodb_cloud_monitoring_free_state }}
   {%- if mongodb_config['cloud'] is defined and mongodb_config['cloud'] is iterable %}
   {%- for item in mongodb_config['cloud'] -%}
   {{ item }}


### PR DESCRIPTION
Free monitoring seems deprecated since 08/2023.
https://www.mongodb.com/docs/manual/administration/free-monitoring/

Mongo fail to restart with this option, from now.