### PR TITLE
feat: support pymongo4 on mongodb_replication script

### DIFF
--- a/.github/workflows/amazonlinux2.yml
+++ b/.github/workflows/amazonlinux2.yml
@@ -16,6 +16,7 @@ jobs:
         molecule_distro:
           - amazonlinux2
         mongodb_version:
+          - '5.0'
           - '4.4'
           - '4.2'
           - '4.0'

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -17,6 +17,7 @@ jobs:
           - centos7
           - centos8
         mongodb_version:
+          - '5.0'
           - '4.4'
           - '4.2'
           - '4.0'

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -17,6 +17,7 @@ jobs:
           - debian9
           - debian10
         mongodb_version:
+          - '5.0'
           - '4.4'
           - '4.2'
           - '4.0'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,6 +17,8 @@ jobs:
           - ubuntu1604
           - ubuntu1804
         mongodb_version:
+          - '5.0'
+          - '4.4'
           - '4.2'
           - '4.0'
           - '3.6'

--- a/README.md
+++ b/README.md
@@ -10,17 +10,21 @@ Ansible role to install and manage [MongoDB](http://www.mongodb.org/).
 - Setup MMS automation agent;
 
 MongoDB support matrix:
+Please refer to these official links:
+- [MongoDB Software Lifecycle Schedules](https://www.mongodb.com/support-policy/lifecycles)
+- [MongoDB Official Repo](https://repo.mongodb.org)
 
-| Distribution   | < MongoDB 3.4 |    MongoDB 3.6     |    MongoDB 4.0     |   MongoDB 4.2      |   MongoDB 4.4      | MongoDB 5.0        |
-| -------------- | :-----------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| Ubuntu 16.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |        :x:         |
-| Ubuntu 18.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |        :x:         |
-| Ubuntu 20.04   |  :no_entry:   |        :x:         |        :x:         |        :x:         | :white_check_mark: | :white_check_mark: |
-| Debian 9.x     |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :o:         |
-| Debian 10.x    |  :no_entry:   |        :x:         |        :x:         | :white_check_mark: | :white_check_mark: |        :o:         |
-| RHEL 7.x       |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :o:         |
-| RHEL 8.x       |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :o:         |
-| Amazon Linux 2 |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :o:         |
+| Distribution   |   MongoDB 3.2   |   MongoDB 3.4   |   MongoDB 3.6   |   MongoDB 4.0   |   MongoDB 4.2   |     MongoDB 4.4     |    MongoDB 5.0     |    MongoDB 6.0     |
+| -------------- | :-------------: | :-------------: | :-------------: | :-------------: | :-------------: | :----------------:  | :----------------: | :----------------: |
+| Ubuntu 16.04   |   :no_entry:    |   :no_entry:    |   :no_entry:    |   :no_entry:    |    :no_entry:   |      :no_entry:     |        :o:         |        :o:         |
+| Ubuntu 18.04   |   :no_entry:    |   :no_entry:    |   :no_entry:    |   :no_entry:    |    :no_entry:   |  :white_check_mark: |        :o:         |        :o:         |
+| Ubuntu 20.04   |   :no_entry:    |   :no_entry:    |   :no_entry:    |   :no_entry:    |    :no_entry:   |  :white_check_mark: | :white_check_mark: |        :o:         |
+| Ubuntu 22.04   |   :no_entry:    |   :no_entry:    |   :no_entry:    |   :no_entry:    |    :no_entry:   |         :o:         | :white_check_mark: | :white_check_mark: |
+| Debian 9.x     |   :no_entry:    |   :no_entry:    |   :no_entry:    |   :no_entry:    |    :no_entry:   |      :no_entry:     |        :o:         |        :o:         |
+| Debian 10.x    |   :no_entry:    |   :no_entry:    |   :no_entry:    |   :no_entry:    |    :no_entry:   |      :no_entry:     |        :o:         |        :o:         |
+| RHEL 7.x       |   :no_entry:    |   :no_entry:    |   :no_entry:    |   :no_entry:    |    :no_entry:   |      :no_entry:     |        :o:         |        :o:         |
+| RHEL 8.x       |   :no_entry:    |   :no_entry:    |   :no_entry:    |   :no_entry:    |    :no_entry:   |      :no_entry:     |        :o:         |        :o:         |
+| Amazon Linux 2 |   :no_entry:    |   :no_entry:    |   :no_entry:    |   :no_entry:    |    :no_entry:   |      :no_entry:     |        :o:         |        :o:         |
 
 - :white_check_mark: - fully tested
 - :o: - not tested yet

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@ Ansible role to install and manage [MongoDB](http://www.mongodb.org/).
 
 MongoDB support matrix:
 
-| Distribution   | < MongoDB 3.4 |    MongoDB 3.6     |    MongoDB 4.0     |   MongoDB 4.2      |   MongoDB 4.4      |
-| -------------- | :-----------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| Ubuntu 16.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |
-| Ubuntu 18.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |
-| Ubuntu 20.04   |  :no_entry:   |        :x:         |        :x:         |        :x:         | :white_check_mark: |
-| Debian 9.x     |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Debian 10.x    |  :no_entry:   |        :x:         |        :x:         | :white_check_mark: | :white_check_mark: |
-| RHEL 7.x       |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| RHEL 8.x       |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Amazon Linux 2 |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Distribution   | < MongoDB 3.4 |    MongoDB 3.6     |    MongoDB 4.0     |   MongoDB 4.2      |   MongoDB 4.4      | MongoDB 5.0        |
+| -------------- | :-----------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| Ubuntu 16.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |        :x:         |
+| Ubuntu 18.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |        :x:         |
+| Ubuntu 20.04   |  :no_entry:   |        :x:         |        :x:         |        :x:         | :white_check_mark: | :white_check_mark: |
+| Debian 9.x     |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :o:         |
+| Debian 10.x    |  :no_entry:   |        :x:         |        :x:         | :white_check_mark: | :white_check_mark: |        :o:         |
+| RHEL 7.x       |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :o:         |
+| RHEL 8.x       |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :o:         |
+| Amazon Linux 2 |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :o:         |
 
 - :white_check_mark: - fully tested
+- :o: - not tested yet
 - :x: - don't have official support
 - :no_entry: - MongoDB has reached EOL
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,4 +148,3 @@ mongodb_sharding_members:
     shard_address: 172.17.0.6:27017
     
 config_server_replset_name: cfgsvr_replset
-config_server_primary_ip: 127.0.0.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@ mongodb_apt_key_id:
   "4.4": "20691eec35216c63caf66ce1656408e390cfb1f5"
   "5.0": "F5679A222C647C87527C2F8CB00A0BD1E2C63C11"
   "6.0": "39BD841E4BE5FB195A65400E6A26B1AE64C3C388"
+  "7.0": "E58830201F7DD82CD808AA84160D26BB1785BA38"
+  "8.0": "4B0752C1BCA238C0B4EE14DC41DE058A4E7DCA05"
 mongodb_apt_key_url:
   "3.2": "https://www.mongodb.org/static/pgp/server-3.2.asc"
   "3.6": "https://www.mongodb.org/static/pgp/server-3.6.asc"
@@ -21,6 +23,9 @@ mongodb_apt_key_url:
   "4.4": "https://www.mongodb.org/static/pgp/server-4.4.asc"
   "5.0": "https://www.mongodb.org/static/pgp/server-5.0.asc"
   "6.0": "https://www.mongodb.org/static/pgp/server-6.0.asc"
+  "7.0": "https://www.mongodb.org/static/pgp/server-7.0.asc"
+  "8.0": "https://www.mongodb.org/static/pgp/server-8.0.asc"
+  
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
 mongodb_pymongo_pip_version: 3.11.3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ mongodb_apt_key_url:
   
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
-mongodb_pymongo_pip_version: 3.11.3
+mongodb_pymongo_pip_version: 4.10.1
 
 mongodb_user_update_password: "on_create"        # MongoDB user password update default policy
 mongodb_manage_service: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,17 +6,21 @@ mongodb_version: "5.0"
 mongodb_apt_key_from_url: false
 mongodb_apt_keyserver: 'hkp://keyserver.ubuntu.com:80'
 mongodb_apt_key_id:
+  "3.2": "42F3E95A2C4F08279C4960ADD68FA50FEA312927"
   "3.6": "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
   "4.0": "9DA31620334BD75D9DCB49F368818C72E52529D4"
   "4.2": "E162F504A20CDF15827F718D4B7C549A058F8B6B"
   "4.4": "20691eec35216c63caf66ce1656408e390cfb1f5"
   "5.0": "F5679A222C647C87527C2F8CB00A0BD1E2C63C11"
+  "6.0": "39BD841E4BE5FB195A65400E6A26B1AE64C3C388"
 mongodb_apt_key_url:
+  "3.2": "https://www.mongodb.org/static/pgp/server-3.2.asc"
   "3.6": "https://www.mongodb.org/static/pgp/server-3.6.asc"
   "4.0": "https://www.mongodb.org/static/pgp/server-4.0.asc"
   "4.2": "https://www.mongodb.org/static/pgp/server-4.2.asc"
   "4.4": "https://www.mongodb.org/static/pgp/server-4.4.asc"
   "5.0": "https://www.mongodb.org/static/pgp/server-5.0.asc"
+  "6.0": "https://www.mongodb.org/static/pgp/server-6.0.asc"
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
 mongodb_pymongo_pip_version: 3.11.3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 mongodb_package: mongodb-org
 mongodb_package_state: present
-mongodb_version: "4.4"
+mongodb_version: "5.0"
 mongodb_apt_key_from_url: false
 mongodb_apt_keyserver: 'hkp://keyserver.ubuntu.com:80'
 mongodb_apt_key_id:
@@ -10,11 +10,13 @@ mongodb_apt_key_id:
   "4.0": "9DA31620334BD75D9DCB49F368818C72E52529D4"
   "4.2": "E162F504A20CDF15827F718D4B7C549A058F8B6B"
   "4.4": "20691eec35216c63caf66ce1656408e390cfb1f5"
+  "5.0": "F5679A222C647C87527C2F8CB00A0BD1E2C63C11"
 mongodb_apt_key_url:
   "3.6": "https://www.mongodb.org/static/pgp/server-3.6.asc"
   "4.0": "https://www.mongodb.org/static/pgp/server-4.0.asc"
   "4.2": "https://www.mongodb.org/static/pgp/server-4.2.asc"
   "4.4": "https://www.mongodb.org/static/pgp/server-4.4.asc"
+  "5.0": "https://www.mongodb.org/static/pgp/server-5.0.asc"
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
 mongodb_pymongo_pip_version: 3.11.3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ mongodb_apt_key_url:
   
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
-mongodb_pymongo_pip_version: 4.10.1
+mongodb_pymongo_pip_version: 3.12.3
 
 mongodb_user_update_password: "on_create"        # MongoDB user password update default policy
 mongodb_manage_service: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -133,3 +133,17 @@ mongodb_set_parameters:
 
 # custom config options
 mongodb_config:
+
+# sharding config
+mongodb_database_name: "foo_service"
+mongodb_sharding_enabled: false
+mongodb_sharding_cluster_role: shard_name
+mongodb_use_mongos: false
+mongodb_sharding_members:
+  - shard_name: shard01
+    shard_address: 172.17.0.5:27017
+  - shard_name: shard02
+    shard_address: 172.17.0.6:27017
+    
+config_server_replset_name: cfgsvr_replset
+config_server_primary_ip: 127.0.0.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ mongodb_apt_key_url:
   
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
-mongodb_pymongo_pip_version: 3.12.3
+mongodb_pymongo_pip_version: 4.15.5
 
 mongodb_user_update_password: "on_create"        # MongoDB user password update default policy
 mongodb_manage_service: true

--- a/library/mongodb_replication.py
+++ b/library/mongodb_replication.py
@@ -161,7 +161,6 @@ host_type:
 '''
 
 import os
-import ssl as ssl_lib
 import time
 import traceback
 from datetime import datetime as dtdatetime
@@ -222,7 +221,7 @@ def check_compatibility(module, client):
 def check_members(state, module, client, host_name, host_port, host_type):
     local_db = client['local']
 
-    if local_db.system.replset.count() > 1:
+    if local_db.system.replset.count_documents({}) > 1:
         module.fail_json(msg='local.system.replset has unexpected contents')
 
     cfg = local_db.system.replset.find_one()
@@ -253,7 +252,7 @@ def add_host(module, client, host_name, host_port, host_type, timeout=180, **kwa
             admin_db = client['admin']
             local_db = client['local']
 
-            if local_db.system.replset.count() > 1:
+            if local_db.system.replset.count_documents({}) > 1:
                 module.fail_json(msg='local.system.replset has unexpected contents')
 
             cfg = local_db.system.replset.find_one()
@@ -296,7 +295,7 @@ def remove_host(module, client, host_name, timeout=180):
         try:
             local_db = client['local']
 
-            if local_db.system.replset.count() > 1:
+            if local_db.system.replset.count_documents({}) > 1:
                 module.fail_json(msg='local.system.replset has unexpected contents')
 
             cfg = local_db.system.replset.find_one()
@@ -338,18 +337,18 @@ def load_mongocnf():
 def wait_for_ok_and_master(module, connection_params, timeout=180):
     start_time = dtdatetime.now()
     while True:
+        client = None
         try:
             client = MongoClient(**connection_params)
-            authenticate(module, client, connection_params["username"], connection_params["password"])
-
             status = client.admin.command('replSetGetStatus', check=False)
             if status['ok'] == 1 and status['myState'] == 1:
                 return
 
         except ServerSelectionTimeoutError:
             pass
-
-        client.close()
+        finally:
+            if client:
+                client.close()
 
         if (dtdatetime.now() - start_time).seconds > timeout:
             module.fail_json(msg='reached timeout while waiting for rs.status() to become ok=1')
@@ -357,17 +356,22 @@ def wait_for_ok_and_master(module, connection_params, timeout=180):
         time.sleep(1)
 
 
-def authenticate(module, client, login_user, login_password):
+def get_mongodb_credentials(module, login_user, login_password):
+    """Get MongoDB credentials from parameters or .mongodb.cnf file.
+    
+    Returns a tuple of (login_user, login_password).
+    In pymongo4+, authentication is done via MongoClient constructor,
+    not via client.admin.authenticate().
+    """
     if login_user is None and login_password is None:
         mongocnf_creds = load_mongocnf()
         if mongocnf_creds is not False:
             login_user = mongocnf_creds['user']
             login_password = mongocnf_creds['password']
-        elif login_password is None and login_user is not None:
-            module.fail_json(msg='when supplying login arguments, both login_user and login_password must be provided')
+    elif login_password is None and login_user is not None:
+        module.fail_json(msg='when supplying login arguments, both login_user and login_password must be provided')
 
-    if login_user is not None and login_password is not None:
-        client.admin.authenticate(login_user, login_password)
+    return login_user, login_password
 
 # =========================================
 # Module execution.
@@ -415,6 +419,8 @@ def main():
 
     replica_set_created = False
 
+    login_user, login_password = get_mongodb_credentials(module, login_user, login_password)
+
     try:
         if replica_set is None:
             module.fail_json(msg='replica_set parameter is required')
@@ -430,11 +436,10 @@ def main():
             }
 
         if ssl:
-            connection_params["ssl"] = ssl
-            connection_params["ssl_cert_reqs"] = getattr(ssl_lib, module.params['ssl_cert_reqs'])
+            connection_params["tls"] = ssl
+            connection_params["tlsAllowInvalidCertificates"] = module.params['ssl_cert_reqs'] == 'CERT_NONE'
 
         client = MongoClient(**connection_params)
-        authenticate(module, client, login_user, login_password)
         client['admin'].command('replSetGetStatus')
 
     except ServerSelectionTimeoutError:
@@ -449,11 +454,10 @@ def main():
             }
 
             if ssl:
-                connection_params["ssl"] = ssl
-                connection_params["ssl_cert_reqs"] = getattr(ssl_lib, module.params['ssl_cert_reqs'])
+                connection_params["tls"] = ssl
+                connection_params["tlsAllowInvalidCertificates"] = module.params['ssl_cert_reqs'] == 'CERT_NONE'
 
             client = MongoClient(**connection_params)
-            authenticate(module, client, login_user, login_password)
             if state == 'present':
                 new_host = {'_id': 0, 'host': "{0}:{1}".format(host_name, host_port)}
                 if priority != 1.0:
@@ -471,7 +475,6 @@ def main():
 
     # reconnect again
     client = MongoClient(**connection_params)
-    authenticate(module, client, login_user, login_password)
     check_compatibility(module, client)
     check_members(state, module, client, host_name, host_port, host_type)
 

--- a/molecule/cluster/molecule.yml
+++ b/molecule/cluster/molecule.yml
@@ -46,7 +46,7 @@ provisioner:
     converge: ${MOLECULE_PLAYBOOK:-../default/converge.yml}
     prepare:  ${MOLECULE_PLAYBOOK:-../default/prepare.yml}
   env:
-    MONGODB_VERSION: ${MONGODB_VERSION:-4.4}
+    MONGODB_VERSION: ${MONGODB_VERSION:-5.0}
     MONGODB_PACKAGE: ${MONGODB_PACKAGE:-mongodb-org}
     AUTH_STATE: ${AUTH_STATE:-disabled}
     REPLICASET: ${REPLICASET:-testrs}

--- a/molecule/shard/converge.yml
+++ b/molecule/shard/converge.yml
@@ -1,0 +1,56 @@
+---
+- name: Converge
+  hosts: config_server
+  tasks:
+    - name: "Include ansible-role-mongodb"
+      include_role:
+        name: "ansible-role-mongodb"
+  vars:
+    mongodb_package: "{{ lookup('env','MONGODB_PACKAGE') }}"
+    mongodb_version: "{{ lookup('env','MONGODB_VERSION') }}"
+    mongodb_security_authorization: "{{ lookup('env', 'AUTH_STATE') }}"
+    mongodb_storage_dbpath: /var/lib/mongodb
+    mongodb_net_bindip: 0.0.0.0
+    mongodb_login_host: "{{ hostvars['config_server1'].ansible_default_ipv4.address }}"
+
+    mongodb_users:
+      - {
+      name: testUser,
+      password: passw0rd,
+      roles: readWrite,
+      database: admin
+      }
+
+- name: Converge
+  hosts: shard_server
+  tasks:
+    - name: "Include ansible-role-mongodb"
+      include_role:
+        name: "ansible-role-mongodb"
+  vars:
+    mongodb_package: "{{ lookup('env','MONGODB_PACKAGE') }}"
+    mongodb_version: "{{ lookup('env','MONGODB_VERSION') }}"
+    mongodb_security_authorization: "{{ lookup('env', 'AUTH_STATE') }}"
+    mongodb_storage_dbpath: /var/lib/mongodb
+    mongodb_net_bindip: 0.0.0.0
+
+    mongodb_users:
+      - {
+      name: testUser,
+      password: passw0rd,
+      roles: readWrite,
+      database: admin
+      }
+
+- name: Converge
+  hosts: mongos
+  tasks:
+    - name: "Include ansible-role-mongodb"
+      include_role:
+        name: "ansible-role-mongodb"
+  vars:
+    mongodb_package: "{{ lookup('env','MONGODB_PACKAGE') }}"
+    mongodb_version: "{{ lookup('env','MONGODB_VERSION') }}"
+    mongodb_security_authorization: "{{ lookup('env', 'AUTH_STATE') }}"
+    mongodb_storage_dbpath: /var/lib/mongodb
+    mongodb_net_bindip: 0.0.0.0

--- a/molecule/shard/molecule.yml
+++ b/molecule/shard/molecule.yml
@@ -91,7 +91,7 @@ provisioner:
     converge: ${MOLECULE_PLAYBOOK:-../shard/converge.yml}
     prepare:  ${MOLECULE_PLAYBOOK:-../default/prepare.yml}
   env:
-    MONGODB_VERSION: ${MONGODB_VERSION:-4.4}
+    MONGODB_VERSION: ${MONGODB_VERSION:-5.0}
     MONGODB_PACKAGE: ${MONGODB_PACKAGE:-mongodb-org}
     AUTH_STATE: ${AUTH_STATE:-disabled}
     REPLICASET: ${REPLICASET:-testrs}

--- a/molecule/shard/molecule.yml
+++ b/molecule/shard/molecule.yml
@@ -1,0 +1,144 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  set -e
+  yamllint .
+  ansible-lint .
+  flake8 library --ignore=E501,E402
+platforms:
+  - name: config_server1
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - config_server
+    docker_networks: 
+      - name: ${MOLECULE_SCENARIO_NAME}
+    publish_all_ports: true
+  - name: config_server2
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - config_server
+    docker_networks: 
+      - name: ${MOLECULE_SCENARIO_NAME}
+    publish_all_ports: true
+  - name: config_server3
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - config_server
+    docker_networks: 
+      - name: ${MOLECULE_SCENARIO_NAME}
+    publish_all_ports: true
+  - name: shard01
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - shard_server
+    docker_networks: 
+      - name: ${MOLECULE_SCENARIO_NAME}
+    publish_all_ports: true
+  - name: shard02
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - shard_server
+    docker_networks: 
+      - name: ${MOLECULE_SCENARIO_NAME}
+    publish_all_ports: true
+  - name: mongos
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+    groups:
+      - mongos
+    docker_networks: 
+      - name: ${MOLECULE_SCENARIO_NAME}
+    publish_all_ports: true
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      pipelining: true
+  log: true
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-../shard/converge.yml}
+    prepare:  ${MOLECULE_PLAYBOOK:-../default/prepare.yml}
+  env:
+    MONGODB_VERSION: ${MONGODB_VERSION:-4.4}
+    MONGODB_PACKAGE: ${MONGODB_PACKAGE:-mongodb-org}
+    AUTH_STATE: ${AUTH_STATE:-disabled}
+    REPLICASET: ${REPLICASET:-testrs}
+  inventory:
+    host_vars:
+      config_server1:
+        ansible_python_interpreter: auto_silent
+        mongodb_master: true
+        mongodb_replication_params:
+          - host_name: "{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}"
+        mongodb_sharding_enabled: true
+        mongodb_sharding_cluster_role: configsvr
+        mongodb_replication_replset: cfgsvr_replset
+      config_server2:
+        ansible_python_interpreter: auto_silent
+        mongodb_replication_params:
+          - host_name: "{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}"
+        mongodb_sharding_enabled: true
+        mongodb_sharding_cluster_role: configsvr
+        mongodb_replication_replset: cfgsvr_replset
+      config_server3:
+        ansible_python_interpreter: auto_silent
+        mongodb_replication_params:
+          - host_name: "{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}"
+        mongodb_sharding_enabled: true
+        mongodb_sharding_cluster_role: configsvr
+        mongodb_replication_replset: cfgsvr_replset
+      shard01:
+        ansible_python_interpreter: auto_silent
+        mongodb_replication_params:
+          - host_name: "{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}"
+        mongodb_sharding_enabled: true
+        mongodb_sharding_cluster_role: shardsvr
+        mongodb_login_host: "{{ hostvars['shard01'].ansible_default_ipv4.address }}"
+        mongodb_replication_replset: shard01
+      shard02:
+        ansible_python_interpreter: auto_silent
+        mongodb_replication_params:
+          - host_name: "{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}"
+        mongodb_sharding_enabled: true
+        mongodb_sharding_cluster_role: shardsvr
+        mongodb_login_host: "{{ hostvars['shard02'].ansible_default_ipv4.address }}"
+        mongodb_replication_replset: shard02
+      mongos:
+        ansible_python_interpreter: auto_silent
+        mongodb_use_mongos: true
+        config_server_replset_name: cfgsvr_replset
+        config_server_primary_ip: "{{ hostvars['config_server1'].ansible_default_ipv4.address }}"
+verifier:
+  name: ansible

--- a/molecule/shard/verify.yml
+++ b/molecule/shard/verify.yml
@@ -1,0 +1,10 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Example assertion
+    assert:
+      that: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -97,13 +97,5 @@
     - wait when mongodb is started
   when: mongodb_use_mongos
 
-# patch known issue default rw concern
-- name: Set default RW concern
-  community.mongodb.mongodb_shell:
-    login_user: "{{ mongodb_root_admin_name }}"
-    login_password: "{{ mongodb_root_admin_password }}"
-    eval: 'db.adminCommand({"setDefaultRWConcern": 1, "defaultWriteConcern": { "w": 1 }})'
-  when: mongodb_master
-
 - name: Flush all handlers at this point
   meta: flush_handlers

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -34,7 +34,7 @@
     owner: "{{ mongodb_user }}"
     group: "root"
     mode: 0600
-  when: mongodb_replication_replset | length > 0
+  when: mongodb_use_mongos or (mongodb_replication_replset | length > 0)
 
 - name: Create log dir if missing
   file:
@@ -82,6 +82,20 @@
   notify:
     - mongodb restart
     - wait when mongodb is started
+  when: not mongodb_use_mongos
+
+- name: Configure mongos
+  template:
+    src: mongos.conf.j2
+    dest: /etc/mongos.conf
+    backup: true
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - mongodb restart
+    - wait when mongodb is started
+  when: mongodb_use_mongos
 
 - name: Flush all handlers at this point
   meta: flush_handlers

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -97,5 +97,13 @@
     - wait when mongodb is started
   when: mongodb_use_mongos
 
+# patch known issue default rw concern
+- name: Set default RW concern
+  community.mongodb.mongodb_shell:
+    login_user: "{{ mongodb_root_admin_name }}"
+    login_password: "{{ mongodb_root_admin_password }}"
+    eval: 'db.adminCommand({"setDefaultRWConcern": 1, "defaultWriteConcern": { "w": 1 }})'
+  when: mongodb_master
+
 - name: Flush all handlers at this point
   meta: flush_handlers

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -18,7 +18,7 @@
 
 - name: Fail when used wrong mongodb_version variable
   fail:
-    msg: "mongodb_version variable should be '3.6' or '4.0', '4.2', '4.4', or '5.0"
+    msg: "mongodb_version variable should be '3.2', '3.6', '4.0', '4.2', '4.4', '5.0', or '6.0'"
   when: (mongodb_package == 'mongodb-org' and
         (mongodb_version is not defined
          or mongodb_repository[mongodb_major_version] is not defined))

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -18,7 +18,7 @@
 
 - name: Fail when used wrong mongodb_version variable
   fail:
-    msg: "mongodb_version variable should be '3.2', '3.6', '4.0', '4.2', '4.4', '5.0', or '6.0'"
+    msg: "mongodb_version variable should be '3.2', '3.6', '4.0', '4.2', '4.4', '5.0', '6.0', '7.0' or '8.0'"
   when: (mongodb_package == 'mongodb-org' and
         (mongodb_version is not defined
          or mongodb_repository[mongodb_major_version] is not defined))

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -18,7 +18,7 @@
 
 - name: Fail when used wrong mongodb_version variable
   fail:
-    msg: "mongodb_version variable should be '3.6' or '4.0', '4.2' or '4.4'"
+    msg: "mongodb_version variable should be '3.6' or '4.0', '4.2', '4.4', or '5.0"
   when: (mongodb_package == 'mongodb-org' and
         (mongodb_version is not defined
          or mongodb_repository[mongodb_major_version] is not defined))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -134,3 +134,7 @@
   include: mms-agent.yml
   when: mongodb_mms_api_key | length > 0
   tags: [mongodb]
+
+- name: Register shard members
+  include: sharding.yml
+  when: mongodb_use_mongos

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,9 +40,10 @@
 
 # patch known issue default rw concern
 - name: Set default read-write concern
-  ansible.builtin.command: "{{ 'mongosh' if mongodb_version.split('.')[0] | int >= 5 else 'mongo' }} -u {{ mongodb_root_admin_name }} -p {{ mongodb_root_admin_password }} --eval 'db.adminCommand({\"setDefaultRWConcern\": 1,\"defaultWriteConcern\": { \"w\": 1 }})'"
+  ansible.builtin.command: "{{ 'mongosh' if mongodb_version.split('.')[0] | int >= 5 else 'mongo' }} --quiet -u {{ mongodb_root_admin_name }} -p {{ mongodb_root_admin_password }} --eval 'db.adminCommand({\"setDefaultRWConcern\": 1,\"defaultWriteConcern\": { \"w\": 1 }})'"
   when: ( mongodb_replication_replset | length > 0
           and mongodb_master is defined and mongodb_master )
+  no_log: true
   tags: [mongodb]
 
 - name: Include replication configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
   ansible.builtin.command: "{{ 'mongosh' if mongodb_version.split('.')[0] | int >= 5 else 'mongo' }} --quiet -u {{ mongodb_root_admin_name }} -p {{ mongodb_root_admin_password }} --eval 'db.adminCommand({\"setDefaultRWConcern\": 1,\"defaultWriteConcern\": { \"w\": 1 }})'"
   when: ( mongodb_replication_replset | length > 0
           and mongodb_master is defined and mongodb_master )
-  no_log: true
+  no_log: false
   tags: [mongodb]
 
 - name: Include replication configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,11 +38,16 @@
         and mongodb_master is defined and mongodb_master )
   tags: [mongodb]
 
-# patch known issue default rw concern
+# patch known issue default read-write concern on MongoDB Version > 5.0
 - name: Set default read-write concern
-  ansible.builtin.command: "{{ 'mongosh' if mongodb_version.split('.')[0] | int >= 5 else 'mongo' }} --quiet -u {{ mongodb_root_admin_name }} -p {{ mongodb_root_admin_password }} --eval 'db.adminCommand({\"setDefaultRWConcern\": 1,\"defaultWriteConcern\": { \"w\": 1 }})'"
-  when: ( mongodb_replication_replset | length > 0
-          and mongodb_master is defined and mongodb_master and mongodb_sharding_enabled is false)
+  ansible.builtin.command: >
+    mongosh --quiet -u {{ mongodb_root_admin_name }} -p {{ mongodb_root_admin_password }}
+    --eval 'db.adminCommand({"setDefaultRWConcern": 1, "defaultWriteConcern": { "w": 1 }})'
+  when: 
+    - mongodb_version.split('.')[0] | int > 5
+    - mongodb_replication_replset | length > 0
+    - mongodb_master is defined and mongodb_master
+    - mongodb_sharding_enabled is false
   no_log: true
   tags: [mongodb]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,7 +80,7 @@
   when: ( mongodb_replication_replset
         and mongodb_security_authorization == 'enabled'
         and mongodb_master is defined and mongodb_master )
-  no_log: false
+  no_log: true
   tags: [mongodb]
 
 - name: create normal users without replicaset

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
 - name: Set default read-write concern
   ansible.builtin.command: "{{ 'mongosh' if mongodb_version.split('.')[0] | int >= 5 else 'mongo' }} --quiet -u {{ mongodb_root_admin_name }} -p {{ mongodb_root_admin_password }} --eval 'db.adminCommand({\"setDefaultRWConcern\": 1,\"defaultWriteConcern\": { \"w\": 1 }})'"
   when: ( mongodb_replication_replset | length > 0
-          and mongodb_master is defined and mongodb_master )
+          and mongodb_master is defined and mongodb_master and mongodb_sharding_enabled is false)
   no_log: false
   tags: [mongodb]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,7 +80,7 @@
   when: ( mongodb_replication_replset
         and mongodb_security_authorization == 'enabled'
         and mongodb_master is defined and mongodb_master )
-  no_log: true
+  no_log: false
   tags: [mongodb]
 
 - name: create normal users without replicaset

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
   ansible.builtin.command: "{{ 'mongosh' if mongodb_version.split('.')[0] | int >= 5 else 'mongo' }} --quiet -u {{ mongodb_root_admin_name }} -p {{ mongodb_root_admin_password }} --eval 'db.adminCommand({\"setDefaultRWConcern\": 1,\"defaultWriteConcern\": { \"w\": 1 }})'"
   when: ( mongodb_replication_replset | length > 0
           and mongodb_master is defined and mongodb_master and mongodb_sharding_enabled is false)
-  no_log: false
+  no_log: true
   tags: [mongodb]
 
 - name: Include replication configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,25 @@
   include_tasks: configure.yml
   tags: [mongodb]
 
+- name: Include replication and auth configuration
+  include_tasks: replication_init_auth.yml
+  when: ( mongodb_replication_replset | length > 0
+        and mongodb_security_authorization == 'enabled'
+        and mongodb_master is defined and mongodb_master )
+  tags: [mongodb]
+
+# patch known issue default rw concern
+- name: Set default read-write concern
+  ansible.builtin.command: "{{ 'mongosh' if mongodb_version.split('.')[0] | int >= 5 else 'mongo' }} -u {{ mongodb_root_admin_name }} -p {{ mongodb_root_admin_password }} --eval 'db.adminCommand({\"setDefaultRWConcern\": 1,\"defaultWriteConcern\": { \"w\": 1 }})'"
+  when: ( mongodb_replication_replset | length > 0
+          and mongodb_master is defined and mongodb_master )
+  tags: [mongodb]
+
+- name: Include replication configuration
+  include_tasks: replication.yml
+  when: mongodb_replication_replset | length > 0
+  tags: [mongodb]
+
 - name: Check whether admin user is already exist
   command: >
     mongo --quiet {{ '--ssl --host ' + mongodb_net_ssl_host if mongodb_net_ssl_mode == 'requireSSL' else '' }} -u {{ mongodb_user_admin_name }} \
@@ -49,26 +68,6 @@
   when: ( mongodb_security_authorization == 'enabled'
           and not mongodb_replication_replset
           and mongodb_user_admin_check.rc != 0 )
-  tags: [mongodb]
-
-# patch known issue default rw concern
-- name: Set default read-write concern
-  ansible.builtin.command: "{{ 'mongosh' if mongodb_version.split('.')[0] | int >= 5 else 'mongo' }} -u {{ mongodb_root_admin_name }} -p {{ mongodb_root_admin_password }} --eval 'db.adminCommand({\"setDefaultRWConcern\": 1,\"defaultWriteConcern\": { \"w\": 1 }})'"
-  when: ( mongodb_security_authorization == 'enabled'
-          and not mongodb_replication_replset
-          and mongodb_master is defined and mongodb_master )
-  tags: [mongodb]
-
-- name: Include replication and auth configuration
-  include_tasks: replication_init_auth.yml
-  when: ( mongodb_replication_replset | length > 0
-        and mongodb_security_authorization == 'enabled'
-        and mongodb_master is defined and mongodb_master )
-  tags: [mongodb]
-
-- name: Include replication configuration
-  include_tasks: replication.yml
-  when: mongodb_replication_replset | length > 0
   tags: [mongodb]
 
 - name: create normal users with replicaset

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,18 +31,6 @@
   include_tasks: configure.yml
   tags: [mongodb]
 
-- name: Include replication and auth configuration
-  include_tasks: replication_init_auth.yml
-  when: ( mongodb_replication_replset | length > 0
-        and mongodb_security_authorization == 'enabled'
-        and mongodb_master is defined and mongodb_master )
-  tags: [mongodb]
-
-- name: Include replication configuration
-  include_tasks: replication.yml
-  when: mongodb_replication_replset | length > 0
-  tags: [mongodb]
-
 - name: Check whether admin user is already exist
   command: >
     mongo --quiet {{ '--ssl --host ' + mongodb_net_ssl_host if mongodb_net_ssl_mode == 'requireSSL' else '' }} -u {{ mongodb_user_admin_name }} \
@@ -61,6 +49,26 @@
   when: ( mongodb_security_authorization == 'enabled'
           and not mongodb_replication_replset
           and mongodb_user_admin_check.rc != 0 )
+  tags: [mongodb]
+
+# patch known issue default rw concern
+- name: Set default read-write concern
+  ansible.builtin.command: "{{ 'mongosh' if mongodb_version.split('.')[0] | int >= 5 else 'mongo' }} -u {{ mongodb_root_admin_name }} -p {{ mongodb_root_admin_password }} --eval 'db.adminCommand({\"setDefaultRWConcern\": 1,\"defaultWriteConcern\": { \"w\": 1 }})'"
+  when: ( mongodb_security_authorization == 'enabled'
+          and not mongodb_replication_replset
+          and mongodb_master is defined and mongodb_master )
+  tags: [mongodb]
+
+- name: Include replication and auth configuration
+  include_tasks: replication_init_auth.yml
+  when: ( mongodb_replication_replset | length > 0
+        and mongodb_security_authorization == 'enabled'
+        and mongodb_master is defined and mongodb_master )
+  tags: [mongodb]
+
+- name: Include replication configuration
+  include_tasks: replication.yml
+  when: mongodb_replication_replset | length > 0
   tags: [mongodb]
 
 - name: create normal users with replicaset

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,20 @@
     - mongodb_replication_replset | length > 0
     - mongodb_master is defined and mongodb_master
     - mongodb_sharding_enabled is false
+    - mongodb_security_authorization == 'enabled'
+  no_log: true
+  tags: [mongodb]
+
+- name: Set default read-write concern when auth is not enabled
+  ansible.builtin.command: >
+    mongosh --quiet
+    --eval 'db.adminCommand({"setDefaultRWConcern": 1, "defaultWriteConcern": { "w": 1 }})'
+  when: 
+    - mongodb_version.split('.')[0] | int > 5
+    - mongodb_replication_replset | length > 0
+    - mongodb_master is defined and mongodb_master
+    - mongodb_sharding_enabled is false
+    - mongodb_security_authorization != 'enabled'
   no_log: true
   tags: [mongodb]
 

--- a/tasks/sharding.yml
+++ b/tasks/sharding.yml
@@ -1,0 +1,19 @@
+- name: Add a replicaset shard
+  community.mongodb.mongodb_shard:
+    login_user: "{{ mongodb_root_admin_name }}"
+    login_password: "{{ mongodb_root_admin_password }}"
+    shard: "{{ item.shard_name }}/{{ item.shard_address }}"
+    state: present
+  loop: "{{ mongodb_sharding_members }}"
+  when: mongodb_use_mongos
+
+- name: Enable sharding on database
+  community.mongodb.mongodb_shard:
+    login_user: "{{ mongodb_root_admin_name }}"
+    login_password: "{{ mongodb_root_admin_password }}"
+    shard: "{{ item.shard_name }}/{{ item.shard_address }}"
+    sharded_databases:
+      - "{{ mongodb_database_name }}"
+    state: present
+  loop: "{{ mongodb_sharding_members }}"
+  when: mongodb_use_mongos

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -31,6 +31,11 @@ processManagement:
   {% endfor %}
   {% endif %}
 
+{% if mongodb_sharding_enabled -%}
+sharding:
+  clusterRole: {{ mongodb_sharding_cluster_role }}
+{% endif %}
+
 {% if mongodb_replication_replset -%}
 replication:
   oplogSizeMB: {{ mongodb_replication_oplogsize | int }}

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -111,18 +111,6 @@ operationProfiling:
   {% endfor %}
   {% endif %}
 
-{% if mongodb_major_version is version("4.0", ">=") -%}
-cloud:
-  monitoring:
-    free:
-      state: {{ mongodb_cloud_monitoring_free_state }}
-  {%- if mongodb_config['cloud'] is defined and mongodb_config['cloud'] is iterable %}
-  {%- for item in mongodb_config['cloud'] -%}
-  {{ item }}
-  {% endfor %}
-  {% endif %}
-{% endif %}
-
 {% if mongodb_set_parameters -%}
 setParameter:
   {% for key, value in mongodb_set_parameters.items() -%}

--- a/templates/mongod.conf.j2
+++ b/templates/mongod.conf.j2
@@ -66,8 +66,10 @@ storage:
   dbPath: {{ mongodb_storage_dbpath }}
   directoryPerDB: {{ mongodb_storage_dirperdb | to_nice_json }}
   engine: {{ mongodb_storage_engine }}
+  {% if mongodb_major_version is version("7.0", "<") -%}
   journal:
     enabled: {{ mongodb_storage_journal_enabled | to_nice_json }}
+  {% endif -%}
   {% if mongodb_storage_engine == 'mmapv1' -%}
   mmapv1:
     quota:

--- a/templates/mongod_init.conf.j2
+++ b/templates/mongod_init.conf.j2
@@ -23,8 +23,10 @@ storage:
   dbPath: {{ mongodb_storage_dbpath }}
   directoryPerDB: {{ mongodb_storage_dirperdb | to_nice_json }}
   engine: {{ mongodb_storage_engine }}
+  {% if mongodb_major_version is version("7.0", "<") -%}
   journal:
     enabled: {{ mongodb_storage_journal_enabled | to_nice_json }}
+  {% endif -%}
   {% if mongodb_storage_engine == 'mmapv1' -%}
   mmapv1:
     quota:

--- a/templates/mongodb.service.j2
+++ b/templates/mongodb.service.j2
@@ -7,9 +7,17 @@ After=network-online.target
 [Service]
 User={{ mongodb_user }}
 {% if mongodb_use_numa | bool %}
+{% if mongodb_use_mongos | bool %}
+ExecStart=/usr/bin/numactl --interleave=all mongos --config /etc/mongos.conf
+{% else %}
 ExecStart=/usr/bin/numactl --interleave=all /usr/bin/mongod --config /etc/mongod.conf
+{% endif %}
+{% else %}
+{% if mongodb_use_mongos | bool %}
+ExecStart=mongos --config /etc/mongos.conf
 {% else %}
 ExecStart=/usr/bin/mongod --config /etc/mongod.conf
+{% endif %}
 {% endif %}
 # file size
 LimitFSIZE=infinity

--- a/templates/mongos.conf.j2
+++ b/templates/mongos.conf.j2
@@ -1,0 +1,39 @@
+# {{ ansible_managed }}
+
+net:
+  bindIp: {{ mongodb_net_bindip }}
+  {% if mongodb_major_version is version("3.6", "<") -%}
+  http:
+    enabled: {{ mongodb_net_http_enabled | to_nice_json }}
+  {% endif -%}
+  ipv6: {{ mongodb_net_ipv6 | to_nice_json }}
+  maxIncomingConnections: {{ mongodb_net_maxconns }}
+  port: {{ mongodb_net_port }}
+  {% if mongodb_net_ssl_pemfile is defined and mongodb_net_ssl_mode is defined and mongodb_net_ssl == 'enabled' -%}
+  ssl:
+    mode: {{ mongodb_net_ssl_mode }}
+    PEMKeyFile: {{ mongodb_net_ssl_pemfile }}
+  {%- endif %}
+
+processManagement:
+  fork: {{ mongodb_processmanagement_fork | to_nice_json}}
+  {% if mongodb_pidfile_path is defined and mongodb_pidfile_path != '' -%}
+  pidFilePath: {{ mongodb_pidfile_path }}
+  {%- endif %}
+
+security:
+  {% if mongodb_security_authorization == 'enabled' -%}
+  keyFile: {{ mongodb_security_keyfile }}
+  {% endif -%}
+  javascriptEnabled: {{ mongodb_security_javascript_enabled | to_nice_json }}
+
+systemLog:
+  destination: {{ mongodb_systemlog_destination }}
+  {% if mongodb_systemlog_destination == 'file' -%}
+  logAppend: {{ mongodb_systemlog_logappend | to_nice_json }}
+  logRotate: {{ mongodb_systemlog_logrotate }}
+  path: {{ mongodb_systemlog_path }}
+  {%- endif %}
+
+sharding:
+  configDB: {{ config_server_replset_name }}/{{ config_server_primary_ip }}:{{ mongodb_net_port }}

--- a/templates/mongos.conf.j2
+++ b/templates/mongos.conf.j2
@@ -35,5 +35,7 @@ systemLog:
   path: {{ mongodb_systemlog_path }}
   {%- endif %}
 
+{% set mongodb_net_port_map = ':' ~ mongodb_net_port ~ ',' %}
+
 sharding:
-  configDB: {{ config_server_replset_name }}/{{ config_server_primary_ip }}:{{ mongodb_net_port }}
+  configDB: {{ config_server_replset_name }}/{{ groups['config_server'] | map('extract', hostvars, ['fqdn']) | join(mongodb_net_port_map) }}:{{mongodb_net_port}}

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,11 +1,13 @@
 ---
 mongodb_repository:
+  "5.0": "https://repo.mongodb.org/yum/amazon/2/mongodb-org/5.0/x86_64/"
   "4.4": "https://repo.mongodb.org/yum/amazon/2/mongodb-org/4.4/x86_64/"
   "4.2": "https://repo.mongodb.org/yum/amazon/2/mongodb-org/4.2/x86_64/"
   "4.0": "https://repo.mongodb.org/yum/amazon/2/mongodb-org/4.0/x86_64/"
   "3.6": "https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/3.6/x86_64/"
 
 mongodb_repository_gpgkey:
+  "5.0": "https://www.mongodb.org/static/pgp/server-5.0.asc"
   "4.4": "https://www.mongodb.org/static/pgp/server-4.4.asc"
   "4.2": "https://www.mongodb.org/static/pgp/server-4.2.asc"
   "4.0": "https://www.mongodb.org/static/pgp/server-4.0.asc"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,6 +4,7 @@ mongodb_repository:
   "4.0": "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.0 main"
   "4.2": "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.2 main"
   "4.4": "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/4.4 main"
+  "5.0": "deb http://repo.mongodb.org/apt/debian {{ ansible_distribution_release }}/mongodb-org/5.0 main"
 
 mongodb_pymongo_package: "{{ 'python3-pymongo' if ansible_facts['python'].version.major == 3 else 'python-pymongo' }}"
 mongodb_pymongo_deps:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,12 +4,14 @@ mongodb_repository:
   "4.0": "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.0/$basearch/"
   "4.2": "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.2/$basearch/"
   "4.4": "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.4/$basearch/"
+  "5.0": "https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/5.0/$basearch/"
 
 mongodb_repository_gpgkey:
   "3.6": "https://www.mongodb.org/static/pgp/server-3.6.asc"
   "4.0": "https://www.mongodb.org/static/pgp/server-4.0.asc"
   "4.2": "https://www.mongodb.org/static/pgp/server-4.2.asc"
   "4.4": "https://www.mongodb.org/static/pgp/server-4.4.asc"
+  "5.0": "https://www.mongodb.org/static/pgp/server-5.0.asc"
 
 mongodb_pidfile_path: "{{ '/var/run/mongodb/mongod.pid' if ('mongodb-org' in mongodb_package) else '' }}"
 

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -7,7 +7,9 @@ mongodb_repository:
   "4.4": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse"
   "5.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/5.0 multiverse"
   "6.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/6.0 multiverse"
-
+  "7.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/7.0 multiverse"
+  "8.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/8.0 multiverse"
+  
 mongodb_pymongo_package: "{{ 'python3-pymongo' if ansible_facts['python'].version.major == 3 else 'python-pymongo' }}"
 mongodb_pymongo_deps:
   - "{{ 'python3-dev' if ansible_facts['python'].version.major == 3 else 'python-dev' }}"

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -4,6 +4,7 @@ mongodb_repository:
   "4.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.0 multiverse"
   "4.2": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.2 multiverse"
   "4.4": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse"
+  "5.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/5.0 multiverse"
 
 mongodb_pymongo_package: "{{ 'python3-pymongo' if ansible_facts['python'].version.major == 3 else 'python-pymongo' }}"
 mongodb_pymongo_deps:

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,10 +1,12 @@
 ---
 mongodb_repository:
+  "3.2": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/3.2 multiverse"
   "3.6": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/3.6 multiverse"
   "4.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.0 multiverse"
   "4.2": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.2 multiverse"
   "4.4": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse"
   "5.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/5.0 multiverse"
+  "6.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/6.0 multiverse"
 
 mongodb_pymongo_package: "{{ 'python3-pymongo' if ansible_facts['python'].version.major == 3 else 'python-pymongo' }}"
 mongodb_pymongo_deps:


### PR DESCRIPTION
Following the official [migration guide](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html) from pymongo3 to pymongo4, the key changes are:

1. Removed `client.admin.authenticate()` calls - In pymongo4, `Database.authenticate()` is removed. Authentication is now done by passing username and password directly to the `MongoClient` constructor.
2. Renamed `authenticate()` function to `get_mongodb_credentials()` - This function now only retrieves credentials from parameters or `.mongodb.cnf` file and returns them, without calling the removed `authenticate()` method.
3. Replaced `.count()` with `.count_documents({})` - The `Collection.count()` method is removed in pymongo4. Updated all 4 occurrences in `check_members()`, `add_host()`, and `remove_host()` functions.
5. Updated SSL parameters - Renamed `ssl` to `tls` and `ssl_cert_reqs` to `tlsAllowInvalidCertificates` as per pymongo4 naming conventions.
6. Removed unused `ssl_lib` import - No longer needed since we're not using `getattr(ssl_lib, ...)` anymore.
7. Fixed `wait_for_ok_and_master()` - Removed `authenticate()` call and improved resource handling with proper finally block to close the client.
